### PR TITLE
Add role permissions for necessary CreateNewFilter functionality

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -258,6 +258,9 @@
                 },{
 
                     "participant": []
+                },{
+
+                    "clinician": []
                 }],
                 "parameters": [{
                     "name": "scope",
@@ -1092,6 +1095,8 @@
                 "operationId": "listQuestions",
                 "security": [{
                     "admin": []
+                },  {
+                  "clinician": []
                 }],
                 "parameters": [{
                     "name": "scope",
@@ -1201,6 +1206,8 @@
                 "operationId": "getQuestion",
                 "security": [{
                     "participant": []
+                }, {
+                    "clinician": []
                 }],
                 "parameters": [{
                     "name": "language",
@@ -2256,6 +2263,8 @@
                 "operationId": "listUserSurveys",
                 "security": [{
                     "participant": []
+                },{
+                    "clinician": []
                 }],
                 "parameters": [{
                     "name": "language",


### PR DESCRIPTION
#### What's this PR do?
Adds `clinician` role to appropriate endpoints necessary for CreateNewFilter functionality

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/RR-416

#### How should this be manually tested?
Run backend and client and `Create New Filter` started from the `/clinician/wizard' endpoint

#### Any background context you want to provide?
#### Screenshots (if appropriate):