### PR TITLE
use type id instead of type name for consent document endpoint by type

### DIFF
--- a/controllers/consent-document.controller.js
+++ b/controllers/consent-document.controller.js
@@ -18,10 +18,10 @@ exports.getConsentDocument = function getConsentDocument(req, res) {
         .catch(shared.handleError(res));
 };
 
-exports.getConsentDocumentByTypeName = function getConsentDocumentByTypeName(req, res) {
-    const typeName = _.get(req, 'swagger.params.typeName.value');
+exports.getConsentDocumentByTypeId = function getConsentDocumentByTypeId(req, res) {
+    const typeId = _.get(req, 'swagger.params.typeId.value');
     const language = _.get(req, 'swagger.params.language.value');
-    req.models.consentDocument.getConsentDocumentByTypeName(typeName, { language })
+    req.models.consentDocument.getConsentDocumentByTypeId(typeId, { language })
         .then(result => res.status(200).json(result))
         .catch(shared.handleError(res));
 };

--- a/controllers/user-consent-document.controller.js
+++ b/controllers/user-consent-document.controller.js
@@ -22,11 +22,11 @@ exports.getUserConsentDocument = function getUserConsentDocument(req, res) {
         .catch(shared.handleError(res));
 };
 
-exports.getUserConsentDocumentByTypeName = function getUserConsentDocumentByTypeName(req, res) {
+exports.getUserConsentDocumentByTypeId = function getUserConsentDocumentByTypeId(req, res) {
     const userId = req.user.id;
-    const typeName = _.get(req, 'swagger.params.typeName.value');
+    const typeId = _.get(req, 'swagger.params.typeId.value');
     const language = _.get(req, 'swagger.params.language.value');
-    req.models.userConsentDocument.getUserConsentDocumentByTypeName(userId, typeName, { language })
+    req.models.userConsentDocument.getUserConsentDocumentByTypeId(userId, typeId, { language })
         .then(result => res.status(200).json(result))
         .catch(shared.handleError(res));
 };

--- a/locales/en.json
+++ b/locales/en.json
@@ -23,7 +23,7 @@
 	"answerToBeSkippedAnswered": "Conditionally to be skipped questions are answered.",
 	"answerQxNotInSurvey": "Invalid question ids for answers.",
 	"qxReplaceWhenActiveSurveys": "Question in active surveys cannot be removed or replaced.",
-	"consentTypeNotFound": "No such consent type.",
+	"consentTypeNotFound": "No active document of consent type is found.",
 	"consentTypeDeleteOnConsent": "Consent type cannot be removed because it is used by one or more consents.",
 	"smtpNotSpecified": "Smtp specifications are not specified.",
 	"smtpTextNotSpecified": "Email content and/or subject not specified for reset token.",

--- a/models/dao/consent-document.dao.js
+++ b/models/dao/consent-document.dao.js
@@ -120,23 +120,15 @@ module.exports = class ConsentDocumentDAO extends Translatable {
             .then(result => this.updateText(result, options.language));
     }
 
-    getConsentDocumentByTypeName(typeName, options = {}) {
-        const ConsentType = this.db.ConsentType;
-        const ConsentDocument = this.db.ConsentDocument;
-        return ConsentType.findOne({
+    getConsentDocumentByTypeId(typeId, options = {}) {
+        return this.db.ConsentDocument.findOne({
             raw: true,
-            where: { name: typeName },
-            attributes: ['id'],
+            where: { typeId },
+            attributes: ['id', 'typeId'],
         })
-            .then((consentType) => {
-                if (consentType) {
-                    const typeId = consentType.id;
-                    return ConsentDocument.findOne({
-                        raw: true,
-                        where: { typeId },
-                        attributes: ['id', 'typeId'],
-                    })
-                        .then(result => this.updateText(result, options.language));
+            .then((result) => {
+                if (result) {
+                    return this.updateText(result, options.language);
                 }
                 return RRError.reject('consentTypeNotFound');
             });

--- a/models/dao/user-consent-document.dao.js
+++ b/models/dao/user-consent-document.dao.js
@@ -62,8 +62,8 @@ module.exports = class UserConsentDocumentDAO extends Base {
             .then(result => this.fillSignature(result, userId, id));
     }
 
-    getUserConsentDocumentByTypeName(userId, typeName, options = {}) {
-        return this.consentDocument.getConsentDocumentByTypeName(typeName, options)
+    getUserConsentDocumentByTypeId(userId, typeId, options = {}) {
+        return this.consentDocument.getConsentDocumentByTypeId(typeId, options)
             .then(result => this.fillSignature(result, userId, result.id));
     }
 };

--- a/swagger.json
+++ b/swagger.json
@@ -1592,17 +1592,18 @@
                 }
             }
         },
-        "/consent-documents/type-name/{typeName}": {
+        "/consent-documents/type/{typeId}": {
             "x-swagger-router-controller": "consent-document.controller",
             "parameters": [{
-                "name": "typeName",
+                "name": "typeId",
                 "in": "path",
                 "required": true,
-                "type": "string"
+                "type": "integer",
+                "minimum": 1
             }],
             "get": {
                 "summary": "Gets consent document (section)",
-                "operationId": "getConsentDocumentByTypeName",
+                "operationId": "getConsentDocumentByTypeId",
                 "parameters": [{
                     "name": "language",
                     "in": "query",
@@ -1839,17 +1840,18 @@
                 }
             }
         },
-        "/user-consent-documents/type-name/{typeName}": {
+        "/user-consent-documents/type/{typeId}": {
             "x-swagger-router-controller": "user-consent-document.controller",
             "parameters": [{
-                "name": "typeName",
+                "name": "typeId",
                 "in": "path",
                 "required": true,
-                "type": "string"
+                "type": "integer",
+                "minimum": 1
             }],
             "get": {
-                "summary": "Gets consent document (section)/signature by type name",
-                "operationId": "getUserConsentDocumentByTypeName",
+                "summary": "Gets consent document (section)/signature by type id",
+                "operationId": "getUserConsentDocumentByTypeId",
                 "security": [{
                     "participant": []
                 }],

--- a/test/consent-document.integration.js
+++ b/test/consent-document.integration.js
@@ -73,10 +73,10 @@ describe('consent document integration', () => {
         };
     };
 
-    const getConsentDocumentByTypeNameFn = function (typeIndex) {
-        return function getConsentDocumentByTypeName(done) {
-            const typeName = history.type(typeIndex).name;
-            rrSuperTest.get(`/consent-documents/type-name/${typeName}`, false, 200)
+    const getConsentDocumentByTypeIdFn = function (typeIndex) {
+        return function getConsentDocumentByTypeId(done) {
+            const typeId = history.type(typeIndex).id;
+            rrSuperTest.get(`/consent-documents/type/${typeId}`, false, 200)
                 .expect((res) => {
                     const expected = history.server(typeIndex);
                     expect(res.body).to.deep.equal(expected);
@@ -102,7 +102,7 @@ describe('consent document integration', () => {
         it(`create consent document of type ${i}`, shared.createConsentDocumentFn(history, i));
         it('logout as super', shared.logoutFn());
         it(`get/verify consent document content of type ${i}`, getConsentDocumentFn(i));
-        it(`get/verify consent document content of type ${i} (type name)`, getConsentDocumentByTypeNameFn(i));
+        it(`get/verify consent document content of type ${i} (type id)`, getConsentDocumentByTypeIdFn(i));
         it('login as super', shared.loginFn(config.superUser));
         it(`add translated (es) consent document ${i}`, shared.translateConsentDocumentFn(i, 'es', history));
         it('logout as super', shared.logoutFn());

--- a/test/consent-document.model.spec.js
+++ b/test/consent-document.model.spec.js
@@ -62,11 +62,11 @@ describe('consent document/type/signature unit', () => {
         };
     };
 
-    const verifyConsentDocumentByTypeNameFn = function (typeIndex) {
+    const verifyConsentDocumentByTypeIdFn = function (typeIndex) {
         return function verifyConsentDocumentByTypeName() {
             const cs = history.server(typeIndex);
-            const typeName = history.type(typeIndex).name;
-            return models.consentDocument.getConsentDocumentByTypeName(typeName)
+            const typeId = history.type(typeIndex).id;
+            return models.consentDocument.getConsentDocumentByTypeId(typeId)
                 .then((result) => {
                     expect(result).to.deep.equal(cs);
                 });
@@ -87,12 +87,12 @@ describe('consent document/type/signature unit', () => {
     _.range(2).forEach((i) => {
         it(`create consent document of type ${i}`, shared.createConsentDocumentFn(history, i));
         it(`verify consent document of type ${i}`, verifyConsentDocumentFn(i));
-        it(`verify consent document of type ${i} (type name)`, verifyConsentDocumentByTypeNameFn(i));
+        it(`verify consent document of type ${i} (type name)`, verifyConsentDocumentByTypeIdFn(i));
         it(`add translated (es) consent document ${i}`, shared.translateConsentDocumentFn(i, 'es', history));
         it(`verify translated (es) consent document of type ${i}`, verifyTranslatedConsentDocumentFn(i, 'es'));
     });
 
-    it('error: no consent documents with type name', () => models.consentDocument.getConsentDocumentByTypeName('Not Here')
+    it('error: no consent documents with type name', () => models.consentDocument.getConsentDocumentByTypeId(99999)
             .then(shared.throwingHandler, shared.expectedErrorHandler('consentTypeNotFound')));
 
     const verifyConsentDocuments = function (userIndex, expectedIndices) {

--- a/test/profile.integration.js
+++ b/test/profile.integration.js
@@ -177,11 +177,11 @@ describe('profile integration', () => {
         };
     };
 
-    const verifySignedDocumentByTypeNameFn = function (expected) {
-        return function verifySignedDocumentByTypeName(done) {
+    const verifySignedDocumentByTypeIdFn = function (expected) {
+        return function verifySignedDocumentByTypeId(done) {
             const server = hxConsentDoc.server(0);
-            const typeName = hxConsentDoc.type(0).name;
-            rrSuperTest.get(`/user-consent-documents/type-name/${typeName}`, true, 200)
+            const typeId = hxConsentDoc.type(0).id;
+            rrSuperTest.get(`/user-consent-documents/type/${typeId}`, true, 200)
                 .expect((res) => {
                     const result = res.body;
                     expect(result.content).to.equal(server.content);
@@ -227,7 +227,7 @@ describe('profile integration', () => {
         it(`register user ${index} with profile survey`, createProfileWithSurveyFn(0));
         it(`verify user ${index} profile`, verifyProfileWithSurveyFn(0, index));
         it(`verify document 0 is not signed by user ${index}`, verifySignedDocumentFn(false));
-        it(`verify document 0 is not signed by user ${index} (type name)`, verifySignedDocumentByTypeNameFn(false));
+        it(`verify document 0 is not signed by user ${index} (type name)`, verifySignedDocumentByTypeIdFn(false));
         it(`update user ${index} profile`, updateProfileWithSurveyFn(0, index));
         it(`verify user ${index} profile`, verifyProfileWithSurveyFn(0, index));
         it(`logout as user ${index}`, shared.logoutFn());
@@ -237,7 +237,7 @@ describe('profile integration', () => {
         it(`register user ${index} with profile survey 0 and doc 0 signature`, createProfileWithSurveyFn(0, [0]));
         it(`verify user ${index} profile`, verifyProfileWithSurveyFn(0, index));
         it(`verify document 0 is signed by user ${index}`, verifySignedDocumentFn(true));
-        it(`verify document 0 is not signed by user ${index} (type name)`, verifySignedDocumentByTypeNameFn(true));
+        it(`verify document 0 is not signed by user ${index} (type name)`, verifySignedDocumentByTypeIdFn(true));
         it(`logout as user ${index}`, shared.logoutFn());
     });
 

--- a/test/profile.model.spec.js
+++ b/test/profile.model.spec.js
@@ -145,9 +145,9 @@ describe('profile unit', () => {
         language = language || 'en';
         return function verifySignedDocumentByTypeName() {
             const server = hxConsentDoc.server(0);
-            const typeName = hxConsentDoc.type(0).name;
+            const typeId = hxConsentDoc.type(0).id;
             const userId = hxUser.id(userIndex);
-            return models.userConsentDocument.getUserConsentDocumentByTypeName(userId, typeName)
+            return models.userConsentDocument.getUserConsentDocumentByTypeId(userId, typeId)
                 .then((result) => {
                     expect(result.content).to.equal(server.content);
                     expect(result.signature).to.equal(expected);

--- a/test/use-cases/consent-demo-simpler.integration.js
+++ b/test/use-cases/consent-demo-simpler.integration.js
@@ -61,7 +61,7 @@ describe('consent demo simpler', () => {
     //* ***** START 2
 
     it('get Terms of Use before registration', (done) => {
-        rrSuperTest.get('/consent-documents/type-name/terms-of-use', false, 200)
+        rrSuperTest.get('/consent-documents/type/1', false, 200)
             .expect((res) => {
                 const result = res.body;
                 expect(!!result.content).to.equal(true);
@@ -110,7 +110,7 @@ describe('consent demo simpler', () => {
     it('login as user', shared.loginFn(userExample));
 
     it('get the Terms of Use document with signature', (done) => {
-        rrSuperTest.get('/user-consent-documents/type-name/terms-of-use', true, 200)
+        rrSuperTest.get('/user-consent-documents/type/1', true, 200)
             .expect((res) => {
                 expect(res.body.content).to.equal(termsOfUse.content);
                 expect(res.body.signature).to.equal(true);
@@ -129,7 +129,7 @@ describe('consent demo simpler', () => {
     //* ***** START 5
 
     it('get the Consents document', (done) => {
-        rrSuperTest.get('/user-consent-documents/type-name/consent', true, 200)
+        rrSuperTest.get('/user-consent-documents/type/2', true, 200)
             .expect((res) => {
                 consents = res.body;
                 expect(res.body.signature).to.equal(false);
@@ -156,7 +156,7 @@ describe('consent demo simpler', () => {
     //* ***** START 7
 
     it('get the Consents document', (done) => {
-        rrSuperTest.get('/user-consent-documents/type-name/consent', true, 200)
+        rrSuperTest.get('/user-consent-documents/type/2', true, 200)
             .expect((res) => {
                 consents = res.body;
                 expect(res.body.signature).to.equal(true);


### PR DESCRIPTION
#### What's this PR do? consent-documents and user-consent-documents endpoint [GET] end points are now available with type id instead of name 
#### Related JIRA tickets: RR-587
#### How should this be manually tested? client implementation will test
#### Any background context you want to provide? NA
#### Screenshots (if appropriate): NA