### PR TITLE
Update /surveys/{id} to allow clinician GET access

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -365,8 +365,9 @@
                 "security": [{
                     "admin": []
                 },{
-
                     "participant": []
+                },{
+                    "clinician": []
                 }],
                 "parameters": [{
                     "name": "language",


### PR DESCRIPTION
#### What's this PR do?
Allow role of type `clinician` to be able to GET `/surveys/{id}` by updating role security permissions in `swagger.json`

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/RR-681

#### How should this be manually tested?
Log in as `clinician` and try to populate survey questions in the filter builder view.

#### Any background context you want to provide?
#### Screenshots (if appropriate):