### PR TITLE
handle integer range max/min correctly when they are zero

### DIFF
--- a/models/dao/answer-common.js
+++ b/models/dao/answer-common.js
@@ -191,8 +191,8 @@ const answerValueToDBFormat = {
         return { value: `${systolic}-${diastolic}` };
     },
     integerRange(value) {
-        const max = value.max || '';
-        const min = value.min || '';
+        const max = (value.max === 0) ? '0' : (value.max || '');
+        const min = (value.min === 0) ? '0' : (value.min || '');
         return { value: `${min}:${max}` };
     },
 };

--- a/test/filter.integration.js
+++ b/test/filter.integration.js
@@ -28,11 +28,11 @@ describe('filter integration', function filterIntegration() {
     it('login as super', shared.loginFn(config.superUser));
 
     ['choice', 'choices', 'integer'].forEach((type) => {
-        _.range(count, count + 6).forEach((index) => {
+        _.range(count, count + 8).forEach((index) => {
             it(`create question ${index}`, qxTests.createQuestionFn({ type }));
             it(`get question ${index}`, qxTests.getQuestionFn(index));
         });
-        count += 6;
+        count += 8;
     });
 
     _.range(count, count + 10).forEach((index) => {

--- a/test/filter.model.spec.js
+++ b/test/filter.model.spec.js
@@ -25,11 +25,11 @@ describe('filter unit', function filterUnit() {
     before(shared.setUpFn());
 
     ['choice', 'choices', 'integer'].forEach((type) => {
-        _.range(count, count + 6).forEach((index) => {
+        _.range(count, count + 8).forEach((index) => {
             it(`create question ${index}`, qxTests.createQuestionFn({ type }));
             it(`get question ${index}`, qxTests.getQuestionFn(index));
         });
-        count += 6;
+        count += 8;
     });
 
     _.range(count, count + 10).forEach((index) => {

--- a/test/util/generator/filter-answerer.js
+++ b/test/util/generator/filter-answerer.js
@@ -5,7 +5,7 @@ const Answerer = require('./answerer');
 module.exports = class FilterAnswerer extends Answerer {
     integer() {
         const answerIndex = this.answerIndex;
-        switch (answerIndex % 4) {
+        switch (answerIndex % 8) {
         case 1:
             return { integerRange: { max: answerIndex } };
         case 2:
@@ -13,6 +13,20 @@ module.exports = class FilterAnswerer extends Answerer {
         case 3: {
             const max = answerIndex + 10;
             const min = answerIndex - 10;
+            return { integerRange: { min, max } };
+        }
+        case 4:
+            return { integerRange: { max: 0 } };
+        case 5:
+            return { integerRange: { min: 0 } };
+        case 6: {
+            const max = answerIndex + 10;
+            const min = 0;
+            return { integerRange: { min, max } };
+        }
+        case 7: {
+            const max = 0;
+            const min = -answerIndex - 10;
             return { integerRange: { min, max } };
         }
         default:


### PR DESCRIPTION
#### What's this PR do? Fixes db saving of integer range filters when max or min are 0
#### Related JIRA tickets: RR-688
#### How should this be manually tested? Tests from client that max/min 0 end points are saved/loaded correctly for filters
#### Any background context you want to provide? NO
#### Screenshots (if appropriate): NA