### PR TITLE
Provision system with OS zip package.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM quay.io/aptible/nodejs:v6.9.x
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install python2.7 -y && \
     apt-get install make -y && \
-    apt-get install build-essential g++ -y
+    apt-get install build-essential g++ -y && \
+    apt-get install zip -y
 
 ENV PYTHON /usr/bin/python2.7
 


### PR DESCRIPTION
#### What's this PR do?

Adds the `zip` package to the `Dockerfile`.  This needs to be installed on the operating system, so that CSVs can be zipped and password protected before being uploaded to Amazon's S3 service.

#### Related JIRA tickets:

https://jira.amida-tech.com/browse/RR-578