### PR TITLE
Fix absolute path '/tmp' to relative path 'tmp' for Windows

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -41,7 +41,7 @@ const all = {
         resetExpires: 3600,
         resetExpiresUnit: 'seconds',
     },
-    tmpDirectory: '/tmp',
+    tmpDirectory: 'tmp',
     cohortBucket: 'recreg-dev-cohorts',
     awsSecretAccessKey: null,
     awsAccessKeyId: null,


### PR DESCRIPTION
#### What's this PR do?
The backend code config is currently written such that Cohort Shaping's .csv write/read occurs at `/tmp` – which works as expected in OS X and Linux File Systems (`/` is the root), but not as expected on Windows File Systems (`/` is `C:/`).
This updates the absolute path (`/tmp`) ref in the app's `config.js` to a relative path (`tmp`) such that it deposits the file into the relative path from the project folder's perspective.

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/RR-782

#### How should this be manually tested?
#### Any background context you want to provide?
#### Screenshots (if appropriate):