### PR TITLE
Bug/rr 785 patch surveys delete old answer rule

### DIFF
--- a/models/dao/survey.dao.js
+++ b/models/dao/survey.dao.js
@@ -404,7 +404,6 @@ module.exports = class SurveyDAO extends Translatable {
                         return null;
                     })
                     .then(() => {
-                        console.log('>>>>> surveyPatch.questions || surveyPatch.sections');
                         if (!(surveyPatch.questions || surveyPatch.sections)) {
                             return null;
                         }
@@ -660,12 +659,10 @@ module.exports = class SurveyDAO extends Translatable {
                                             const result = Object.assign(qxMap[surveyQuestion.questionId], { required: surveyQuestion.required }); // eslint-disable-line max-len
                                             return result;
                                         });
-                                        console.log('>>>>> survey.dao > Survey.findOne > answerRuleInfos: ', answerRuleInfos);
                                         answerRuleInfos.forEach(({ questionId, rule }) => {
                                             if (questionId) {
-                                                console.log('>>>>> survey.dao > Survey.findOne > questionId: ', questionId);
                                                 const question = qxMap[questionId];
-                                                if (!question.enableWhen) { // FIXME FIXME FIXME: Problem here
+                                                if (!question.enableWhen) {
                                                     question.enableWhen = [];
                                                 }
                                                 question.enableWhen.push(rule);


### PR DESCRIPTION
…a 500 response before

#### What's this PR do?
Fixes the server 500 response when trying to update an existing Survey that already had enableWhen answerRule conditions associated to its questions.

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/RR-785

#### How should this be manually tested?
#### Any background context you want to provide?
#### Screenshots (if appropriate):