### PR TITLE
Remove first name and last name questions from seed survey

### DIFF
--- a/seed.js
+++ b/seed.js
@@ -17,15 +17,7 @@ const gapDemoSurveys = require('./test/fixtures/example/gap-demo-survey');
 
 const survey = {
     name: 'Alzheimer',
-    questions: [{
-        text: 'First Name',
-        required: true,
-        type: 'text',
-    }, {
-        text: 'Last Name',
-        required: true,
-        type: 'text',
-    },
+    questions: [
     {
         text: 'Zip Code',
         required: true,


### PR DESCRIPTION
#### What's this PR do?
Just removes the first name and last name questions from the seed script survey.

#### Related JIRA tickets:
There used to be a ticket for this, however for some reason it was either closed or lost. This is a simple fix that we held off on doing when Clay and his team were testing their mobile client. Now that their testing has been complete for a while now, we can go ahead and do this in lieu of wiping the dev instance DB.

#### How should this be manually tested?
#### Any background context you want to provide?
#### Screenshots (if appropriate):