### PR TITLE
Bug/rr 804 researcher profile

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4568,9 +4568,6 @@
                 "meta": {
                     "$ref": "#/definitions/surveyMeta"
                 },
-                "enableWhen": {
-                    "$ref": "#/definitions/newEnableWhen"
-                },
                 "sections": {
                     "type": "array",
                     "items": {

--- a/swagger.json
+++ b/swagger.json
@@ -1261,6 +1261,12 @@
                 "summary": "Updates registry user profile",
                 "operationId": "updateProfile",
                 "security": [{
+                    "admin": []
+                },
+                {
+                    "clinician": []
+                },
+                {
                     "participant": []
                 }],
                 "parameters": [{
@@ -1285,6 +1291,12 @@
                 "summary": "Gets user profile",
                 "operationId": "getProfile",
                 "security": [{
+                    "admin": []
+                },
+                {
+                    "clinician": []
+                },
+                {
                     "participant": []
                 }],
                 "responses": {
@@ -4555,6 +4567,9 @@
                 },
                 "meta": {
                     "$ref": "#/definitions/surveyMeta"
+                },
+                "enableWhen": {
+                    "$ref": "#/definitions/newEnableWhen"
                 },
                 "sections": {
                     "type": "array",


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.

Please refer to [Tettra](https://app.tettra.co/teams/amida/pages/amida-pull-request-and-code-review-guide) for PR review guidelines.

#### What does this PR do?
Allows a Researcher to access their "profile" (`Account Settings`) and make changes.

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/RR-809

#### How should this be manually tested?
To see the bug in action:
- Either go to http://dev.recreg.amida-demo.com/ or to a local current `develop` branch and log in as a `clinician/researcher`
- Have Developer Tools/Browser Console open
- Click on upper right-hand corner button (displaying your email) and select `Account Settings`
- Observe the 403 when attempting to GET `/profiles`
--- Note that this also occurred for `admin` role accounts, as well. This also grants the ability for `admin`s to access their profile.

To see the bug resolved:
- Pull this branch and repeat the above steps
- Observe the 403 no longer occurring and allowing the Researcher to access the profile data and fields

#### Background/Context
This does not address other issues pertaining to profiles in general, referred to in
https://jira.amida-tech.com/browse/RR-810
and
https://jira.amida-tech.com/browse/RR-811

THIS DOES NOT FIX THE FAILURE TO SAVE PROFILE INFORMATION!
Fixing saving requires fixing the input fields in the UI which are very, very old and outdated with the new field-type validations introduced a while back:
https://jira.amida-tech.com/browse/RR-882

#### Screenshots (if appropriate):
