### PR TITLE
Email test fix

### DIFF
--- a/config/test.js
+++ b/config/test.js
@@ -14,7 +14,6 @@ module.exports = {
         poolIdle: 1000,
     },
     tmpDirectory: path.join(__dirname, '../test/generated'),
-    cohortBucket: 'recregtest',
     constantContact: {
         baseApiUrl: 'http://turnip.test',
         token: 'turnip',


### PR DESCRIPTION
#### What does this PR do?
Removes the hard coded cohort bucket value from the dev config file and rely on the developer to set the environment variable to match the one used by the test file server (`RECREG_COHORT_BUCKET=file-repo-test`).

#### Related JIRA tickets:

#### How should this be manually tested?
1. Set `FILE_SERVICE_BASE_URL=http://app-7976.on-aptible.com` and `RECREG_COHORT_BUCKET=file-repo-test` in your .env file.
1. Check that the cohort_email.integration.js tests pass

#### Background/Context

#### Screenshots (if appropriate):
