### PR TITLE
survey-published query parameter to show only questions that are on p…

### DIFF
--- a/controllers/question.controller.js
+++ b/controllers/question.controller.js
@@ -58,12 +58,15 @@ exports.listQuestions = function listQuestions(req, res) {
     const commonOnly = _.get(req, 'swagger.params.common-only.value');
     const federated = _.get(req, 'swagger.params.federated.value');
     let isIdentifying = _.get(req, 'swagger.params.isIdentifying.value');
+    const surveyPublished = _.get(req, 'swagger.params.survey-published.value');
     if (user.role === 'admin') {
         isIdentifying = true;
     } else if (user.role === 'participant') {
         isIdentifying = false;
     }
-    const options = { scope, language, surveyId, commonOnly, federated, isIdentifying };
+    const options = {
+        scope, language, surveyId, surveyPublished, commonOnly, federated, isIdentifying,
+    };
     req.models.question.listQuestions(options)
         .then(questions => res.status(200).json(questions))
         .catch(shared.handleError(res));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,7 @@
 const gulp = require('gulp');
 const plato = require('es6-plato');
 const lintRules = require('./.eslintrc.js');
-const filename = require('./readAnalysisFile.js');
+const filename = require('./readAnalysisFile.js'); // eslint-disable-line import/no-unresolved
 
 const src = filename.includes('.js') ? `./${filename}` : `./${filename}/**`;
 

--- a/models/db/db-generator.js
+++ b/models/db/db-generator.js
@@ -179,6 +179,19 @@ const defineTables = function (sequelize, Sequelize, schema) {
     });
 
     SurveyQuestion.belongsTo(Question, questionBelongsTo());
+    SurveyQuestion.belongsTo(Survey, {
+        as: 'survey',
+        onUpdate: 'NO ACTION',
+        foreignKey: {
+            allowNull: false,
+            fieldName: 'surveyId',
+            field: 'survey_id',
+            references: {
+                model: 'survey',
+                key: 'id',
+            },
+        },
+    });
 
     SurveySection.belongsTo(Section, {
         as: 'section',

--- a/swagger.json
+++ b/swagger.json
@@ -1419,6 +1419,12 @@
                     "description": "identifying flag",
                     "required": false,
                     "type": "boolean"
+                }, {
+                    "name": "survey-published",
+                    "in": "query",
+                    "description": "in a published survey",
+                    "required": false,
+                    "type": "boolean"
                 }],
                 "responses": {
                     "200": {
@@ -5889,8 +5895,7 @@
             "type": "array",
             "items": {
                 "$ref": "#/definitions/question"
-            },
-            "minLength": 1
+            }
         },
         "questionTextUpdate": {
             "type": "object",

--- a/test/question_published.integration.js
+++ b/test/question_published.integration.js
@@ -1,0 +1,102 @@
+/* global describe,before,it */
+
+'use strict';
+
+process.env.NODE_ENV = 'test';
+
+const _ = require('lodash');
+
+const config = require('../config');
+
+const SharedIntegration = require('./util/shared-integration');
+const RRSuperTest = require('./util/rr-super-test');
+const Generator = require('./util/generator');
+const History = require('./util/history');
+const SurveyHistory = require('./util/survey-history');
+const surveyCommon = require('./util/survey-common');
+const questionCommon = require('./util/question-common');
+
+describe('question published integration', () => {
+    const rrSuperTest = new RRSuperTest();
+    const generator = new Generator();
+    const shared = new SharedIntegration(rrSuperTest, generator);
+
+    const hxQuestion = new History();
+    const hxSurvey = new SurveyHistory();
+
+    const surveyTests = new surveyCommon.IntegrationTests(
+        rrSuperTest, generator, hxSurvey, hxQuestion);
+    const tests = new questionCommon.IntegrationTests(rrSuperTest, { generator, hxQuestion });
+
+    const listQuestions = (indices) => {
+        it('list all questions (complete)', tests.listQuestionsFn('complete'));
+
+        it('list all questions (summary)', tests.listQuestionsFn('summary'));
+
+        it('list published questions (complete)', tests.listQuestionsFn({
+            indices,
+            scope: 'summary',
+            surveyPublished: true,
+        }));
+
+        it('list published questions (complete)', tests.listQuestionsFn({
+            indices,
+            scope: 'summary',
+            surveyPublished: true,
+        }));
+    };
+
+    before(shared.setUpFn());
+
+    it('login as super', shared.loginFn(config.superUser));
+
+    listQuestions([]);
+
+    _.range(20).forEach((index) => {
+        it(`create question ${index}`, tests.createQuestionFn());
+        it(`get question ${index}`, tests.getQuestionFn(index));
+    });
+
+    listQuestions([]);
+
+    it('create published survey 0 from questions 0, 2, 4, 6, 8',
+        surveyTests.createSurveyQxHxFn([0, 2, 4, 6, 8], { status: 'published' }));
+
+    listQuestions([0, 2, 4, 6, 8]);
+
+    it('create draft survey 1 from questions 10, 12, 14, 16, 18',
+        surveyTests.createSurveyQxHxFn([10, 12, 14, 16, 18], { status: 'draft' }));
+
+    listQuestions([0, 2, 4, 6, 8]);
+
+    it('create draft survey 2 from questions 11, 13, 15, 17, 19',
+        surveyTests.createSurveyQxHxFn([11, 13, 15, 17, 19], { status: 'draft' }));
+
+    listQuestions([0, 2, 4, 6, 8]);
+
+    it('patch survey 2 to status published',
+        surveyTests.patchSurveyFn(2, { status: 'published' }));
+
+    listQuestions([0, 2, 4, 6, 8, 11, 13, 15, 17, 19]);
+
+    it('create published survey 3 from questions 1, 3, 5, 7, 9',
+        surveyTests.createSurveyQxHxFn([1, 3, 5, 7, 9]));
+
+    listQuestions([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 13, 15, 17, 19]);
+
+    it('patch survey 2 to status retired',
+        surveyTests.patchSurveyFn(2, { status: 'retired' }));
+
+    listQuestions([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+    it('patch survey 1 to status published',
+        surveyTests.patchSurveyFn(1, { status: 'published' }));
+
+    listQuestions([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 18]);
+
+    it('delete survey 0', surveyTests.deleteSurveyFn(0));
+
+    listQuestions([1, 3, 5, 7, 9, 10, 12, 14, 16, 18]);
+
+    it('logout as user', shared.logoutFn());
+});

--- a/test/question_published.integration.js
+++ b/test/question_published.integration.js
@@ -35,11 +35,11 @@ describe('question published integration', () => {
 
         it('list published questions (complete)', tests.listQuestionsFn({
             indices,
-            scope: 'summary',
+            scope: 'complete',
             surveyPublished: true,
         }));
 
-        it('list published questions (complete)', tests.listQuestionsFn({
+        it('list published questions (summary)', tests.listQuestionsFn({
             indices,
             scope: 'summary',
             surveyPublished: true,

--- a/test/question_published.model.spec.js
+++ b/test/question_published.model.spec.js
@@ -30,11 +30,11 @@ describe('question published unit', function questionPublishedUnit() {
 
         it('list published questions (complete)', tests.listQuestionsFn({
             indices,
-            scope: 'summary',
+            scope: 'complete',
             surveyPublished: true,
         }));
 
-        it('list published questions (complete)', tests.listQuestionsFn({
+        it('list published questions (summary)', tests.listQuestionsFn({
             indices,
             scope: 'summary',
             surveyPublished: true,

--- a/test/question_published.model.spec.js
+++ b/test/question_published.model.spec.js
@@ -1,0 +1,93 @@
+/* global describe,before,it */
+
+'use strict';
+
+process.env.NODE_ENV = 'test';
+
+const _ = require('lodash');
+
+const SharedSpec = require('./util/shared-spec.js');
+const Generator = require('./util/generator');
+const History = require('./util/history');
+const SurveyHistory = require('./util/survey-history');
+const surveyCommon = require('./util/survey-common');
+const questionCommon = require('./util/question-common');
+
+describe('question published unit', function questionPublishedUnit() {
+    const generator = new Generator();
+    const shared = new SharedSpec(generator);
+
+    const hxQuestion = new History();
+    const hxSurvey = new SurveyHistory();
+
+    const surveyTests = new surveyCommon.SpecTests(generator, hxSurvey, hxQuestion);
+    const tests = new questionCommon.SpecTests({ generator, hxQuestion });
+
+    const listQuestions = (indices) => {
+        it('list all questions (complete)', tests.listQuestionsFn('complete'));
+
+        it('list all questions (summary)', tests.listQuestionsFn('summary'));
+
+        it('list published questions (complete)', tests.listQuestionsFn({
+            indices,
+            scope: 'summary',
+            surveyPublished: true,
+        }));
+
+        it('list published questions (complete)', tests.listQuestionsFn({
+            indices,
+            scope: 'summary',
+            surveyPublished: true,
+        }));
+    };
+
+    before(shared.setUpFn());
+
+    listQuestions([]);
+
+    _.range(20).forEach((index) => {
+        it(`create question ${index}`, tests.createQuestionFn());
+        it(`get question ${index}`, tests.getQuestionFn(index));
+    });
+
+    listQuestions([]);
+
+    it('create published survey 0 from questions 0, 2, 4, 6, 8',
+        surveyTests.createSurveyQxHxFn([0, 2, 4, 6, 8], { status: 'published' }));
+
+    listQuestions([0, 2, 4, 6, 8]);
+
+    it('create draft survey 1 from questions 10, 12, 14, 16, 18',
+        surveyTests.createSurveyQxHxFn([10, 12, 14, 16, 18], { status: 'draft' }));
+
+    listQuestions([0, 2, 4, 6, 8]);
+
+    it('create draft survey 2 from questions 11, 13, 15, 17, 19',
+        surveyTests.createSurveyQxHxFn([11, 13, 15, 17, 19], { status: 'draft' }));
+
+    listQuestions([0, 2, 4, 6, 8]);
+
+    it('patch survey 2 to status published',
+        surveyTests.patchSurveyFn(2, { status: 'published' }));
+
+    listQuestions([0, 2, 4, 6, 8, 11, 13, 15, 17, 19]);
+
+    it('create published survey 3 from questions 1, 3, 5, 7, 9',
+        surveyTests.createSurveyQxHxFn([1, 3, 5, 7, 9]));
+
+    listQuestions([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 13, 15, 17, 19]);
+
+    it('patch survey 2 to status retired',
+        surveyTests.patchSurveyFn(2, { status: 'retired' }));
+
+    listQuestions([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+    it('patch survey 1 to status published',
+        surveyTests.patchSurveyFn(1, { status: 'published' }));
+
+    listQuestions([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 14, 16, 18]);
+
+    it('delete survey 0', surveyTests.deleteSurveyFn(0));
+
+    listQuestions([1, 3, 5, 7, 9, 10, 12, 14, 16, 18]);
+});

--- a/test/util/generator/survey-generator.js
+++ b/test/util/generator/survey-generator.js
@@ -137,6 +137,9 @@ module.exports = class SurveyGenerator {
         const surveyIndex = this.surveyIndex;
         const name = `name_${surveyIndex}`;
         const result = { name };
+        if (options.status) {
+            result.status = options.status;
+        }
 
         result.questions = questionIds.map((id) => {
             let required = Boolean(surveyIndex % 2);

--- a/test/util/question-common.js
+++ b/test/util/question-common.js
@@ -158,13 +158,14 @@ const BaseTests = class BaseTests {
                 if (typeof options === 'string') {
                     query = { scope: options };
                 } else {
-                    query = options;
+                    query = _.omit(options, 'indices');
                 }
             }
+            const indices = options && options.indices;
             return self.listQuestionsPx(query)
                 .then((questions) => {
                     const fields = getFieldsForList(query && query.scope);
-                    let expected = hxQuestion.listServers(fields);
+                    let expected = hxQuestion.listServers(fields, indices);
                     if (options && options.federated) {
                         const federatedMap = self.hxIdentifiers.federated;
                         expected = expected.reduce((r, question) => {
@@ -343,7 +344,11 @@ const IntegrationTests = class QuestionIntegrationTests extends BaseTests {
     }
 
     listQuestionsPx(query) {
-        return this.rrSuperTest.get('/questions', true, 200, query).then(res => res.body);
+        const options = query && _.omit(query, ['surveyPublished']);
+        if (query && query.surveyPublished) {
+            options['survey-published'] = true;
+        }
+        return this.rrSuperTest.get('/questions', true, 200, options).then(res => res.body);
     }
 
     addIdentifierPx(questionId, allIdentifiers) {


### PR DESCRIPTION
…ublished surveys

If this PR fixes a bug, you _must_ add test cases representative of the bug.

Please refer to [Tettra](https://app.tettra.co/teams/amida/pages/amida-pull-request-and-code-review-guide) for PR review guidelines.

#### What does this PR do? Adds ability to filter [GET] /questions based on published surveys with a query parameter 'survey-published'.

#### Related JIRA tickets: RR-914

#### How should this be manually tested?

1) Create draft surveys, published surveys, stand-alone questions.
2) Call [GET] /questions with or without 'survey-published' parameter.

#### Background/Context

NA

#### Screenshots (if appropriate):

NA