### PR TITLE
initial implementation of scale type

### DIFF
--- a/lib/json-schema.js
+++ b/lib/json-schema.js
@@ -317,7 +317,7 @@ _.set(schema, 'definitions.newSurveyQuestion', {
             },
             meta: {
                 type: 'object',
-                required: [ 'scaleLimits' ],
+                required: ['scaleLimits'],
                 properties: {
                     scaleLimits: {
                         type: 'object',
@@ -602,11 +602,8 @@ _.set(schema, 'definitions.newQuestion', {
                 $ref: '#/definitions/newIdentifier',
             },
             meta: {
-                $ref: '#/definitions/questionMeta',
-            },
-            meta: {
                 type: 'object',
-                required: [ 'scaleLimits' ],
+                required: ['scaleLimits'],
                 properties: {
                     scaleLimits: {
                         type: 'object',

--- a/lib/json-schema.js
+++ b/lib/json-schema.js
@@ -296,6 +296,56 @@ _.set(schema, 'definitions.newSurveyQuestion', {
             },
         },
         additionalProperties: false,
+    }, {
+        type: 'object',
+        required: ['text', 'type', 'required', 'meta'],
+        properties: {
+            text: { type: 'string' },
+            instruction: { type: 'string' },
+            required: { type: 'boolean' },
+            isIdentifying: { type: 'boolean' },
+            type: { type: 'string', enum: ['scale'] },
+            common: {
+                type: 'boolean',
+            },
+            sections: {
+                type: 'array',
+                items: {
+                    $ref: '#/definitions/newSection',
+                },
+                minItems: 1,
+            },
+            meta: {
+                type: 'object',
+                required: [ 'scaleLimits' ],
+                properties: {
+                    scaleLimits: {
+                        type: 'object',
+                        properties: {
+                            min: {
+                                type: 'number',
+                            },
+                            max: {
+                                type: 'number',
+                            },
+                        },
+                        minProperties: 1,
+                        additionalProperties: false,
+                    },
+                },
+                additionalProperties: true,
+            },
+            multiple: {
+                type: 'boolean',
+            },
+            maxCount: {
+                type: 'integer',
+                minimum: 1,
+            },
+            enableWhen: {
+                $ref: '#/definitions/newEnableWhen',
+            },
+        },
     }],
 });
 
@@ -529,6 +579,54 @@ _.set(schema, 'definitions.newQuestion', {
                     },
                     additionalProperties: false,
                 },
+            },
+        },
+        additionalProperties: false,
+    }, {
+        type: 'object',
+        required: ['text', 'type', 'meta'],
+        properties: {
+            text: { type: 'string' },
+            instruction: { type: 'string' },
+            isIdentifying: { type: 'boolean' },
+            type: { type: 'string', enum: ['scale'] },
+            common: {
+                type: 'boolean',
+            },
+            multiple: { type: 'boolean' },
+            maxCount: { type: 'integer', minimum: 1 },
+            questionIdentifier: {
+                $ref: '#/definitions/newIdentifier',
+            },
+            answerIdentifier: {
+                $ref: '#/definitions/newIdentifier',
+            },
+            meta: {
+                $ref: '#/definitions/questionMeta',
+            },
+            meta: {
+                type: 'object',
+                required: [ 'scaleLimits' ],
+                properties: {
+                    scaleLimits: {
+                        type: 'object',
+                        properties: {
+                            min: {
+                                type: 'number',
+                            },
+                            max: {
+                                type: 'number',
+                            },
+                        },
+                        minProperties: 1,
+                        additionalProperties: false,
+                    },
+                },
+                additionalProperties: true,
+            },
+            parentId: {
+                type: 'integer',
+                minimum: 1,
             },
         },
         additionalProperties: false,

--- a/lib/json-schema.js
+++ b/lib/json-schema.js
@@ -298,7 +298,7 @@ _.set(schema, 'definitions.newSurveyQuestion', {
         additionalProperties: false,
     }, {
         type: 'object',
-        required: ['text', 'type', 'required', 'meta'],
+        required: ['text', 'type', 'required', 'scaleLimits'],
         properties: {
             text: { type: 'string' },
             instruction: { type: 'string' },
@@ -316,24 +316,7 @@ _.set(schema, 'definitions.newSurveyQuestion', {
                 minItems: 1,
             },
             meta: {
-                type: 'object',
-                required: ['scaleLimits'],
-                properties: {
-                    scaleLimits: {
-                        type: 'object',
-                        properties: {
-                            min: {
-                                type: 'number',
-                            },
-                            max: {
-                                type: 'number',
-                            },
-                        },
-                        minProperties: 1,
-                        additionalProperties: false,
-                    },
-                },
-                additionalProperties: true,
+                $ref: '#/definitions/questionMeta',
             },
             multiple: {
                 type: 'boolean',
@@ -342,10 +325,24 @@ _.set(schema, 'definitions.newSurveyQuestion', {
                 type: 'integer',
                 minimum: 1,
             },
+            scaleLimits: {
+                type: 'object',
+                properties: {
+                    min: {
+                        type: 'number',
+                    },
+                    max: {
+                        type: 'number',
+                    },
+                },
+                minProperties: 1,
+                additionalProperties: false,
+            },
             enableWhen: {
                 $ref: '#/definitions/newEnableWhen',
             },
         },
+        additionalProperties: false,
     }],
 });
 
@@ -584,7 +581,7 @@ _.set(schema, 'definitions.newQuestion', {
         additionalProperties: false,
     }, {
         type: 'object',
-        required: ['text', 'type', 'meta'],
+        required: ['text', 'type', 'scaleLimits'],
         properties: {
             text: { type: 'string' },
             instruction: { type: 'string' },
@@ -602,24 +599,20 @@ _.set(schema, 'definitions.newQuestion', {
                 $ref: '#/definitions/newIdentifier',
             },
             meta: {
+                $ref: '#/definitions/questionMeta',
+            },
+            scaleLimits: {
                 type: 'object',
-                required: ['scaleLimits'],
                 properties: {
-                    scaleLimits: {
-                        type: 'object',
-                        properties: {
-                            min: {
-                                type: 'number',
-                            },
-                            max: {
-                                type: 'number',
-                            },
-                        },
-                        minProperties: 1,
-                        additionalProperties: false,
+                    min: {
+                        type: 'number',
+                    },
+                    max: {
+                        type: 'number',
                     },
                 },
-                additionalProperties: true,
+                minProperties: 1,
+                additionalProperties: false,
             },
             parentId: {
                 type: 'integer',

--- a/locales/en.json
+++ b/locales/en.json
@@ -84,5 +84,7 @@
 	"answerInvalidAssesSurveys": "Survey assigned to assessment is not unique.",
 	"answerInvalidSurveyInAsses": "Survey does not belong to assessment.",
 	"feedbackSurveyNoDeletedDefault": "Invalid id(s) for feedback survey and/or linked survey.",
-	"feedbackSurveyNoWrongType": "Wrong type(s) for feedback survey and/or linked survey."
+	"feedbackSurveyNoWrongType": "Wrong type(s) for feedback survey and/or linked survey.",
+	"questionScaleMinGTMax": "Minimum value of scale type question must be less than maximum value",
+	"answerOutOfScale": "Answer to a scale type question must be within the minimum and maximum"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -85,6 +85,6 @@
 	"answerInvalidSurveyInAsses": "Survey does not belong to assessment.",
 	"feedbackSurveyNoDeletedDefault": "Invalid id(s) for feedback survey and/or linked survey.",
 	"feedbackSurveyNoWrongType": "Wrong type(s) for feedback survey and/or linked survey.",
-	"questionScaleMinGTMax": "Minimum value of scale type question must be less than maximum value",
-	"answerOutOfScale": "Answer to a scale type question must be within the minimum and maximum"
+	"questionScaleMinGTMax": "Scale question maximum cannot be greater than minimum.",
+	"answerOutOfScale": "Answer {{0}} is out of scale."
 }

--- a/migration/migrations/20180206155614-scale-question-type.js
+++ b/migration/migrations/20180206155614-scale-question-type.js
@@ -1,11 +1,9 @@
 'use strict';
 
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return queryInterface.addColumn('question', 'parameter', {
+    up: (queryInterface, Sequelize) => queryInterface.addColumn('question', 'parameter', {
         type: Sequelize.TEXT,
         allowNull: true,
-        defaultValue: null
-    });
-  },
+        defaultValue: null,
+    }).then(() => queryInterface.sequelize.query('INSERT INTO question_type(name, created_at) VALUES (\'scale\', NOW())')),
 };

--- a/migration/migrations/20180206155614-scale-question-type.js
+++ b/migration/migrations/20180206155614-scale-question-type.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.addColumn('question', 'parameter', {
+        type: Sequelize.TEXT,
+        allowNull: true,
+        defaultValue: null
+    });
+  },
+};

--- a/migration/models/question-type.model.js
+++ b/migration/models/question-type.model.js
@@ -24,7 +24,7 @@ module.exports = function Table(sequelize, DataTypes) {
                     const names = [
                         'text', 'choice', 'choices', 'bool', 'integer', 'float',
                         'zip', 'date', 'pounds', 'year', 'month', 'day',
-                        'feet-inches', 'blood-pressure', 'choice-ref',
+                        'feet-inches', 'blood-pressure', 'choice-ref', 'scale',
                     ];
                     const ps = names.map(name => this.create({ name }));
                     return SPromise.all(ps);

--- a/migration/models/question-type.model.js
+++ b/migration/models/question-type.model.js
@@ -24,7 +24,7 @@ module.exports = function Table(sequelize, DataTypes) {
                     const names = [
                         'text', 'choice', 'choices', 'bool', 'integer', 'float',
                         'zip', 'date', 'pounds', 'year', 'month', 'day',
-                        'feet-inches', 'blood-pressure', 'choice-ref', 'scale',
+                        'feet-inches', 'blood-pressure', 'choice-ref',
                     ];
                     const ps = names.map(name => this.create({ name }));
                     return SPromise.all(ps);

--- a/models/dao/answer-common.js
+++ b/models/dao/answer-common.js
@@ -55,6 +55,9 @@ const getValueAnswerGenerator = (function getValueAnswerGeneratorGen() {
             return { dateRange };
         },
         float(value) { return { floatValue: parseFloat(value) }; },
+        scale(value) {
+            return { numberValue: parseFloat(value) };
+        },
         bloodPressure(value) {
             const pieces = value.split('-');
             return {

--- a/models/dao/answer.dao.js
+++ b/models/dao/answer.dao.js
@@ -269,7 +269,7 @@ module.exports = class AnswerDAO extends Base {
 
     validateAnswerValues(userAnswers) {
         const ids = userAnswers.map(({ questionId }) => questionId);
-        const attributes = ['id', 'type', 'meta'];
+        const attributes = ['id', 'type', 'parameter'];
         const where = { id: { [Op.in]: ids } };
         return this.db.Question.findAll({ where, attributes, raw: true })
             .then(questions => _.keyBy(questions, 'id'))
@@ -279,9 +279,10 @@ module.exports = class AnswerDAO extends Base {
                     if (!question) {
                         throw new RRError('answerQxNotInSurvey');
                     }
-                    const { type, meta } = question;
+                    const { type, parameter } = question;
                     if (type === 'scale' && (answer || answers)) { // Currently only validating scale answer values
-                        const { min, max } = meta.scaleLimits;
+                        const paramSplit = parameter.split(':');
+                        const [min, max] = paramSplit.map(v => (v ? parseFloat(v) : null));
                         let values;
                         if (answer) {
                             values = [answer.numberValue];

--- a/models/dao/answer.dao.js
+++ b/models/dao/answer.dao.js
@@ -290,10 +290,10 @@ module.exports = class AnswerDAO extends Base {
                             values = answers.map(({ numberValue }) => numberValue);
                         }
                         values.forEach((value) => {
-                            if (min !== null && value < min){
+                            if (min !== null && value < min) {
                                 throw new RRError('answerOutOfScale', value);
                             }
-                            if (max !== null && value > max){
+                            if (max !== null && value > max) {
                                 throw new RRError('answerOutOfScale', value);
                             }
                         });

--- a/models/dao/answer.dao.js
+++ b/models/dao/answer.dao.js
@@ -267,10 +267,46 @@ module.exports = class AnswerDAO extends Base {
             });
     }
 
+    validateAnswerValues(userAnswers) {
+        const ids = userAnswers.map(({ questionId }) => questionId);
+        const attributes = ['id', 'type', 'meta'];
+        const where = { id: { [Op.in]: ids } };
+        return this.db.Question.findAll({ where, attributes, raw: true })
+            .then(questions => _.keyBy(questions, 'id'))
+            .then((questionMap) => {
+                userAnswers.forEach(({ questionId, answer, answers }) => {
+                    const question = questionMap[questionId];
+                    if (!question) {
+                        throw new RRError('answerQxNotInSurvey');
+                    }
+                    const { type, meta } = question;
+                    if (type === 'scale' && (answer || answers)) { // Currently only validating scale answer values
+                        const { min, max } = meta.scaleLimits;
+                        let values;
+                        if (answer) {
+                            values = [answer.numberValue];
+                        }
+                        if (answers) {
+                            values = answers.map(({ numberValue }) => numberValue);
+                        }
+                        values.forEach((value) => {
+                            if (min !== null && value < min){
+                                throw new RRError('answerOutOfScale', value);
+                            }
+                            if (max !== null && value > max){
+                                throw new RRError('answerOutOfScale', value);
+                            }
+                        });
+                    }
+                });
+            });
+    }
+
     validateAnswers(masterId, answers, status) {
         const Answer = this.db.Answer;
         const surveyId = masterId.surveyId;
-        return this.surveyQuestion.listSurveyQuestions(surveyId, true)
+        return this.validateAnswerValues(answers)
+            .then(() => this.surveyQuestion.listSurveyQuestions(surveyId, true))
             .then((surveyQuestions) => {
                 const answersByQuestionId = _.keyBy(answers, 'questionId');
                 return this.answerRule.getQuestionExpandedSurveyAnswerRules(surveyId)

--- a/models/dao/question.dao.js
+++ b/models/dao/question.dao.js
@@ -660,10 +660,7 @@ module.exports = class QuestionDAO extends Translatable {
                 const { scaleLimits } = patch;
                 if (scaleLimits && question.scaleLimits && question.type === 'scale') {
                     if (!_.isEqual(question.scaleLimits, scaleLimits)) {
-                        const combined = _.cloneDeep(question.scaleLimits);
-                        Object.assign(combined, scaleLimits);
-                        const parameter = parameterJsonToString({ scaleLimits: combined });
-
+                        const parameter = parameterJsonToString({ scaleLimits });
                         Object.assign(record, { parameter });
                     }
                 }

--- a/models/dao/question.dao.js
+++ b/models/dao/question.dao.js
@@ -16,7 +16,32 @@ const cleanDBQuestion = function (question) {
     if (question.common === null) {
         result.common = false;
     }
+    if (result.type === 'scale' && result.parameter) {
+        const limits = question.parameter.split(':');
+        const scaleLimits = {};
+        if (limits[0]) {
+            scaleLimits.min = parseFloat(limits[0]);
+        }
+        if (limits[1]) {
+            scaleLimits.max = parseFloat(limits[1]);
+        }
+        Object.assign(result, { scaleLimits });
+        delete result.parameter;
+    }
     return result;
+};
+
+const parameterJsonToString = function (question) {
+    const scaleLimits = question.scaleLimits;
+    if (scaleLimits) {
+        const min = scaleLimits.min === undefined ? '' : scaleLimits.min;
+        const max = scaleLimits.max === undefined ? '' : scaleLimits.max;
+        if (min !== '' && max !== '' && min > max) {
+            throw new RRError('questionScaleMinGTMax');
+        }
+        return `${min}:${max}`;
+    }
+    return '';
 };
 
 const exportMetaQuestionProperties = function (meta, metaOptions, withChoice, fromQuestion) {
@@ -86,14 +111,13 @@ module.exports = class QuestionDAO extends Translatable {
         const Question = this.db.Question;
         return this.updateChoiceSetReference(question.choiceSetReference, transaction)
             .then((choiceSetId) => {
-                const baseFields = _.omit(question, ['oneOfChoices', 'choices', 'text', 'instruction']);
+                const baseFields = _.omit(question, ['oneOfChoices', 'choices', 'text', 'instruction', 'scaleLimits']);
                 if (choiceSetId) {
                     baseFields.choiceSetId = choiceSetId;
                 }
-                if (question.meta && question.meta.scaleLimits) {
-                    if (question.meta.scaleLimits.min > question.meta.scaleLimits.max) {
-                        throw new RRError('questionScaleMinGTMax');
-                    }
+                const parameter = parameterJsonToString(question);
+                if (parameter) {
+                    baseFields.parameter = parameter;
                 }
                 return Question.create(baseFields, { transaction, raw: true })
                     .then((result) => {
@@ -187,7 +211,7 @@ module.exports = class QuestionDAO extends Translatable {
     getQuestion(qid, options = {}) {
         const Question = this.db.Question;
         const language = options.language;
-        const attributes = ['id', 'type', 'meta', 'multiple', 'maxCount', 'choiceSetId', 'common', 'isIdentifying'];
+        const attributes = ['id', 'type', 'meta', 'multiple', 'maxCount', 'choiceSetId', 'common', 'isIdentifying', 'parameter'];
         return Question.findById(qid, { raw: true, attributes })
             .then((question) => {
                 if (!question) {
@@ -296,7 +320,7 @@ module.exports = class QuestionDAO extends Translatable {
     }
 
     findQuestions({ scope, ids, surveyId, commonOnly, isIdentifying }) {
-        const attributes = ['id', 'type', 'isIdentifying'];
+        const attributes = ['id', 'type', 'isIdentifying', 'parameter'];
         if (scope === 'complete' || scope === 'export') {
             attributes.push('meta', 'multiple', 'maxCount', 'choiceSetId');
         }
@@ -450,8 +474,10 @@ module.exports = class QuestionDAO extends Translatable {
 
     exportQuestions(options = {}) {
         return this.listQuestions({ scope: 'export' })
-            .then(questions => questions.reduce((r, { id, type, text, instruction, meta, choices }) => {  // eslint-disable-line no-param-reassign, max-len
+            .then(questions => questions.reduce((r, { id, type, text, scaleLimits, instruction, meta, choices }) => {  // eslint-disable-line no-param-reassign, max-len
                 const questionLine = { id, type, text, instruction };
+                const parameter = parameterJsonToString({ scaleLimits });
+                Object.assign(questionLine, { parameter });
                 if (meta && options.meta) {
                     Object.assign(questionLine, exportMetaQuestionProperties(meta, options.meta, choices, true)); // eslint-disable-line max-len
                 }
@@ -501,6 +527,9 @@ module.exports = class QuestionDAO extends Translatable {
                         question = { text: record.text, type: record.type, key: record.key };
                         if (record.instruction) {
                             question.instruction = record.instruction;
+                        }
+                        if (record.parameter) {
+                            question.parameter = record.parameter;
                         }
                         if (options.meta) {
                             const meta = importMetaQuestionProperties(record, options.meta, 'question'); // eslint-disable-line max-len

--- a/models/dao/question.dao.js
+++ b/models/dao/question.dao.js
@@ -320,7 +320,6 @@ module.exports = class QuestionDAO extends Translatable {
     }
 
     findQuestions({ scope, ids, surveyId, surveyPublished, commonOnly, isIdentifying }) {
-        const attributes = ['id', 'type', 'isIdentifying'];
         const attributes = ['id', 'type', 'isIdentifying', 'parameter'];
         if (scope === 'complete' || scope === 'export') {
             attributes.push('meta', 'multiple', 'maxCount', 'choiceSetId');
@@ -658,6 +657,16 @@ module.exports = class QuestionDAO extends Translatable {
                     }
                     return null;
                 });
+                const { scaleLimits } = patch;
+                if (scaleLimits && question.scaleLimits && question.type === 'scale') {
+                    if (!_.isEqual(question.scaleLimits, scaleLimits)) {
+                        const combined = _.cloneDeep(question.scaleLimits);
+                        Object.assign(combined, scaleLimits);
+                        const parameter = parameterJsonToString({ scaleLimits: combined });
+
+                        Object.assign(record, { parameter });
+                    }
+                }
                 if (!_.isEmpty(record)) {
                     return this.db.Question.update(record, { where: { id }, transaction: tx });
                 }

--- a/models/dao/question.dao.js
+++ b/models/dao/question.dao.js
@@ -90,6 +90,11 @@ module.exports = class QuestionDAO extends Translatable {
                 if (choiceSetId) {
                     baseFields.choiceSetId = choiceSetId;
                 }
+                if (question.meta && question.meta.scaleLimits) {
+                    if (question.meta.scaleLimits.min > question.meta.scaleLimits.max) {
+                        throw new RRError('questionScaleMinGTMax');
+                    }
+                }
                 return Question.create(baseFields, { transaction, raw: true })
                     .then((result) => {
                         const { text, instruction } = question;

--- a/models/db/question-type.model.js
+++ b/models/db/question-type.model.js
@@ -26,7 +26,7 @@ module.exports = function questionType(sequelize, Sequelize, schema) {
                         'text', 'choice', 'choices', 'bool', 'integer',
                         'float', 'zip', 'date', 'pounds', 'year', 'month',
                         'day', 'feet-inches', 'blood-pressure', 'choice-ref',
-                        'open-choice', 'file',
+                        'open-choice', 'file', 'scale',
                     ];
                     return this.bulkCreate(names.map(name => ({ name })));
                 }

--- a/models/db/question.model.js
+++ b/models/db/question.model.js
@@ -64,6 +64,9 @@ module.exports = function question(sequelize, Sequelize, schema) {
             allowNull: false,
             defaultValue: false,
         },
+        parameter: {
+            type: Sequelize.TEXT,
+        },
     }, {
         freezeTableName: true,
         tableName,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "pg": "^6.2.4",
     "request": "^2.79.0",
     "sequelize": "4.25.2",
-    "swagger-tools": "^0.10.1",
+    "swagger-tools": "^0.10.3",
     "winston": "^2.2.0",
     "xlsx": "^0.8.0"
   },

--- a/swagger.json
+++ b/swagger.json
@@ -4440,6 +4440,9 @@
                         "$ref": "#/definitions/newChoice"
                     },
                     "minItems": 1
+                },
+                "scaleLimits": {
+                    "$ref": "#/definitions/scaleLimits"
                 }
             },
             "minProperties": 2,
@@ -4552,7 +4555,7 @@
                     "$ref": "#/definitions/newEnableWhen"
                 }
             },
-            "maxProperties": 6,
+            "maxProperties": 4,
             "additionalProperties": false
         },
         "sectionPatch": {
@@ -4607,7 +4610,7 @@
                     "$ref": "#/definitions/enableWhen"
                 }
             },
-            "maxProperties": 4,
+            "maxProperties": 6,
             "additionalProperties": false
         },
         "sectionTextUpdate": {
@@ -4761,6 +4764,9 @@
                         "$ref": "#/definitions/choice"
                     },
                     "minItems": 1
+                },
+                "scaleLimits": {
+                    "$ref": "#/definitions/scaleLimits"
                 },
                 "answer": {
                     "$ref": "#/definitions/answer"
@@ -5850,6 +5856,9 @@
                         "$ref": "#/definitions/choice"
                     }
                 },
+                "scaleLimits": {
+                    "$ref": "#/definitions/scaleLimits"
+                },
                 "answer": {
                     "$ref": "#/definitions/answer"
                 }
@@ -6017,8 +6026,24 @@
                     "items": {
                         "$ref": "#/definitions/newChoice"
                     }
+                },
+                "scaleLimits": {
+                    "$ref": "#/definitions/scaleLimits"
                 }
             },
+            "additionalProperties": false
+        },
+        "scaleLimits": {
+            "type": "object",
+            "properties": {
+                "min": {
+                    "type": "number"
+                },
+                "max": {
+                    "type": "number"
+                }
+            },
+            "minProperties": 1,
             "additionalProperties": false
         },
         "linkedAnswer": {

--- a/swagger.json
+++ b/swagger.json
@@ -4295,7 +4295,7 @@
             "enum": [
                 "text", "bool", "integer", "choice", "choices", "float",
                 "date", "year", "month", "day", "choice-ref", "open-choice",
-                "pounds", "zip", "feet-inches", "blood-pressure", "file"
+                "pounds", "zip", "feet-inches", "blood-pressure", "file", "scale"
             ]
         },
         "questionMeta": {
@@ -4440,6 +4440,9 @@
                         "$ref": "#/definitions/newChoice"
                     },
                     "minItems": 1
+                },
+                "scaleLimits": {
+                    "$ref": "#/definitions/scaleLimits"
                 }
             },
             "minProperties": 2,
@@ -4552,7 +4555,7 @@
                     "$ref": "#/definitions/newEnableWhen"
                 }
             },
-            "maxProperties": 4,
+            "maxProperties": 6,
             "additionalProperties": false
         },
         "sectionPatch": {
@@ -4761,6 +4764,9 @@
                         "$ref": "#/definitions/choice"
                     },
                     "minItems": 1
+                },
+                "scaleLimits": {
+                    "$ref": "#/definitions/scaleLimits"
                 },
                 "answer": {
                     "$ref": "#/definitions/answer"
@@ -5850,6 +5856,9 @@
                         "$ref": "#/definitions/choice"
                     }
                 },
+                "scaleLimits": {
+                    "$ref": "#/definitions/scaleLimits"
+                },
                 "answer": {
                     "$ref": "#/definitions/answer"
                 }
@@ -6017,8 +6026,24 @@
                     "items": {
                         "$ref": "#/definitions/newChoice"
                     }
+                },
+                "scaleLimits": {
+                    "$ref": "#/definitions/scaleLimits"
                 }
             },
+            "additionalProperties": false
+        },
+        "scaleLimits": {
+            "type": "object",
+            "properties": {
+                "min": {
+                    "type": "number"
+                },
+                "max": {
+                    "type": "number"
+                }
+            },
+            "minProperties": 1,
             "additionalProperties": false
         },
         "linkedAnswer": {

--- a/swagger.json
+++ b/swagger.json
@@ -4440,9 +4440,6 @@
                         "$ref": "#/definitions/newChoice"
                     },
                     "minItems": 1
-                },
-                "scaleLimits": {
-                    "$ref": "#/definitions/scaleLimits"
                 }
             },
             "minProperties": 2,
@@ -4764,9 +4761,6 @@
                         "$ref": "#/definitions/choice"
                     },
                     "minItems": 1
-                },
-                "scaleLimits": {
-                    "$ref": "#/definitions/scaleLimits"
                 },
                 "answer": {
                     "$ref": "#/definitions/answer"
@@ -5856,9 +5850,6 @@
                         "$ref": "#/definitions/choice"
                     }
                 },
-                "scaleLimits": {
-                    "$ref": "#/definitions/scaleLimits"
-                },
                 "answer": {
                     "$ref": "#/definitions/answer"
                 }
@@ -6026,24 +6017,8 @@
                     "items": {
                         "$ref": "#/definitions/newChoice"
                     }
-                },
-                "scaleLimits": {
-                    "$ref": "#/definitions/scaleLimits"
                 }
             },
-            "additionalProperties": false
-        },
-        "scaleLimits": {
-            "type": "object",
-            "properties": {
-                "min": {
-                    "type": "number"
-                },
-                "max": {
-                    "type": "number"
-                }
-            },
-            "minProperties": 1,
             "additionalProperties": false
         },
         "linkedAnswer": {

--- a/swagger.json
+++ b/swagger.json
@@ -4638,6 +4638,9 @@
                         "$ref": "#/definitions/choicePatch"
                     },
                     "minItems": 1
+                },
+                "scaleLimits": {
+                    "$ref": "#/definitions/scaleLimits"
                 }
             },
             "minProperties": 2,

--- a/test/fixtures/conditional-session/patch/patch-setup.js
+++ b/test/fixtures/conditional-session/patch/patch-setup.js
@@ -113,19 +113,19 @@ module.exports = [{
         questionIndex: 4,
         purpose: 'patchQuestion',
         patch: {
-          scaleLimits: {
-              min: 0,
-              max: 10
-          }
-        }
+            scaleLimits: {
+                min: 0,
+                max: 10,
+            },
+        },
     }, {
         questionIndex: 5,
         purpose: 'patchQuestion',
         patch: {
-          scaleLimits: {
-              min: -9,
-              max: 0
-          }
-        }
+            scaleLimits: {
+                min: -9,
+                max: 0,
+            },
+        },
     }],
 }];

--- a/test/fixtures/conditional-session/patch/patch-setup.js
+++ b/test/fixtures/conditional-session/patch/patch-setup.js
@@ -108,13 +108,23 @@ module.exports = [{
         },
     }],
 }, { // ^9, v 10
-    surveyIndex: 2,
+    surveyIndex: 6,
     mods: [{
-        purpose: 'patchScaleQuestions',
+        questionIndex: 4,
+        purpose: 'patchQuestion',
         patch: {
           scaleLimits: {
               min: 0,
               max: 10
+          }
+        }
+    }, {
+        questionIndex: 5,
+        purpose: 'patchQuestion',
+        patch: {
+          scaleLimits: {
+              min: -9,
+              max: 0
           }
         }
     }],

--- a/test/fixtures/conditional-session/patch/patch-setup.js
+++ b/test/fixtures/conditional-session/patch/patch-setup.js
@@ -107,4 +107,15 @@ module.exports = [{
             instruction: null,
         },
     }],
+}, { // ^9, v 10
+    surveyIndex: 2,
+    mods: [{
+        purpose: 'patchScaleQuestions',
+        patch: {
+          scaleLimits: {
+              min: 0,
+              max: 10
+          }
+        }
+    }],
 }];

--- a/test/fixtures/conditional-session/patch/setup.js
+++ b/test/fixtures/conditional-session/patch/setup.js
@@ -90,8 +90,8 @@ module.exports = [{
     type: 'scale',
     scaleLimits: {
         min: 4,
-        max: 5
-    }
+        max: 5,
+    },
 }, {
     surveyIndex: 6,
     purpose: 'type',
@@ -99,8 +99,8 @@ module.exports = [{
     type: 'scale',
     scaleLimits: {
         min: 0,
-        max: 1
-    }
+        max: 1,
+    },
 }, { // Survey 7
     purpose: 'completeSurvey',
     surveyIndex: 7,

--- a/test/fixtures/conditional-session/patch/setup.js
+++ b/test/fixtures/conditional-session/patch/setup.js
@@ -83,6 +83,24 @@ module.exports = [{
     questionIndex: 3,
     type: 'choice',
     choiceCount: 5,
+}, {
+    surveyIndex: 6,
+    purpose: 'type',
+    questionIndex: 4,
+    type: 'scale',
+    scaleLimits: {
+        min: 4,
+        max: 5
+    }
+}, {
+    surveyIndex: 6,
+    purpose: 'type',
+    questionIndex: 5,
+    type: 'scale',
+    scaleLimits: {
+        min: 0,
+        max: 1
+    }
 }, { // Survey 7
     purpose: 'completeSurvey',
     surveyIndex: 7,

--- a/test/fixtures/json-schema-invalid/new-question.js
+++ b/test/fixtures/json-schema-invalid/new-question.js
@@ -25,4 +25,7 @@ module.exports = [{
     text: 'Example',
     type: 'text',
     oneOfChoices: ['a', 'b', 'c'],
+}, {
+    text: 'Example',
+    type: 'scale',
 }];

--- a/test/fixtures/valids/new-question.js
+++ b/test/fixtures/valids/new-question.js
@@ -23,4 +23,8 @@ module.exports = [{
     text: 'Example',
     type: 'choices',
     choices: [{ text: 'x' }, { text: 'y', type: 'bool' }, { text: 'z', type: 'text' }],
+}, {
+    text: 'Example',
+    type: 'scale',
+    meta: { scaleLimits: { min: 4, max: 9 } },
 }];

--- a/test/fixtures/valids/new-question.js
+++ b/test/fixtures/valids/new-question.js
@@ -26,5 +26,5 @@ module.exports = [{
 }, {
     text: 'Example',
     type: 'scale',
-    meta: { scaleLimits: { min: 4, max: 9 } },
+    scaleLimits: { min: 4, max: 9 },
 }];

--- a/test/fixtures/valids/new-survey.js
+++ b/test/fixtures/valids/new-survey.js
@@ -78,5 +78,23 @@ module.exports = [
             id: 112,
             required: true,
         }],
+    }, {
+        name: 'name_15',
+        questions: [{
+            required: true,
+            text: 'Example1',
+            type: 'scale',
+            meta: { scaleLimits: { min: 4, max: 9 } },
+        }, {
+            required: true,
+            text: 'Example2',
+            type: 'scale',
+            meta: { scaleLimits: { min: 4 } },
+        }, {
+            required: true,
+            text: 'Example3',
+            type: 'scale',
+            meta: { scaleLimits: { max: 9 } },
+        }],
     },
 ];

--- a/test/fixtures/valids/new-survey.js
+++ b/test/fixtures/valids/new-survey.js
@@ -84,17 +84,17 @@ module.exports = [
             required: true,
             text: 'Example1',
             type: 'scale',
-            meta: { scaleLimits: { min: 4, max: 9 } },
+            scaleLimits: { min: 4, max: 9 },
         }, {
             required: true,
             text: 'Example2',
             type: 'scale',
-            meta: { scaleLimits: { min: 4 } },
+            scaleLimits: { min: 4 },
         }, {
             required: true,
             text: 'Example3',
             type: 'scale',
-            meta: { scaleLimits: { max: 9 } },
+            scaleLimits: { max: 9 },
         }],
     },
 ];

--- a/test/question_patch.model.spec.js
+++ b/test/question_patch.model.spec.js
@@ -58,9 +58,9 @@ describe('question patch unit', function questionPatchUnit() {
         it(`verify question 10 scaleLimits (${index})`, tests.verifyQuestionFn(10));
     });
     [
+        { scaleLimits: { min: 10, max: 0 } },
+        { scaleLimits: { min: 5, max: 0 } },
         { scaleLimits: { min: 1, max: 0 } },
-        { scaleLimits: { min: 999999 } },
-        { scaleLimits: { max: -999999 } },
     ].forEach((patch, index) => {
         const options = {
             error: 'questionScaleMinGTMax',

--- a/test/question_patch.model.spec.js
+++ b/test/question_patch.model.spec.js
@@ -38,10 +38,36 @@ describe('question patch unit', function questionPatchUnit() {
     _.range(6).forEach((index) => {
         it(`create question ${index}`, tests.createQuestionFn());
     });
+    _.range(2).forEach((index) => {
+        it(`create question ${index} (scale)`, tests.createQuestionFn({
+            type: 'scale',
+            scaleLimits: { min: 22, max: 42 },
+        }));
+    });
 
-    _.range(10).forEach((index) => {
+    _.range(12).forEach((index) => {
         it(`get question ${index}`, tests.getQuestionFn(index));
     });
+
+    [
+        { scaleLimits: { min: 0, max: 10 } },
+        { scaleLimits: { min: 9 } },
+        { scaleLimits: { max: 11 } },
+    ].forEach((patch, index) => {
+        it(`patch question 10 scaleLimits (${index})`, tests.patchQuestionFn(10, patch));
+        it(`verify question 10 scaleLimits (${index})`, tests.verifyQuestionFn(10));
+    });
+    [
+        { scaleLimits: { min: 1, max: 0 } },
+        { scaleLimits: { min: 999999 } },
+        { scaleLimits: { max: -999999 } },
+    ].forEach((patch, index) => {
+        const options = {
+            error: 'questionScaleMinGTMax',
+        };
+        it(`error: patch invalid scaleLimits (${index})`, tests.errorPatchQuestionFn(11, patch, options));
+    });
+
 
     [
         { text: 'patch_1', instruction: 'instruction_1' },

--- a/test/question_scale.integration.js
+++ b/test/question_scale.integration.js
@@ -1,0 +1,201 @@
+/* global describe,before,it */
+
+'use strict';
+
+/* eslint max-len: 0 */
+
+process.env.NODE_ENV = 'test';
+
+const chai = require('chai');
+const _ = require('lodash');
+
+const models = require('../models');
+
+const config = require('../config');
+const RRSuperTest = require('./util/rr-super-test');
+const SharedIntegration = require('./util/shared-integration.js');
+const Generator = require('./util/generator');
+const History = require('./util/history');
+const SurveyHistory = require('./util/survey-history');
+const questionCommon = require('./util/question-common');
+const surveyCommon = require('./util/survey-common');
+const answerCommon = require('./util/answer-common');
+
+const expect = chai.expect;
+
+describe('scale type question integration', function scaleQuestionIntegration() {
+    const rrSuperTest = new RRSuperTest();
+    const generator = new Generator();
+    const shared = new SharedIntegration(rrSuperTest, generator);
+
+    before(shared.setUpFn());
+
+    const hxQuestion = new History();
+    const hxSurvey = new SurveyHistory();
+    const hxUser = new History();
+
+    const tests = new questionCommon.IntegrationTests(rrSuperTest, { generator, hxQuestion });
+    const surveyTests = new surveyCommon.IntegrationTests(rrSuperTest, generator, hxSurvey, hxQuestion);
+    const answerTests = new answerCommon.IntegrationTests(rrSuperTest, { generator, hxUser, hxSurvey, hxQuestion });
+
+    const cases = [
+        [null, 5],    // 0
+        [5, null],    // 1
+        [7, 81],      // 2
+        [0.5, 1.45],  // 3
+        [1.4, null],  // 4
+        [null, 5.15], // 5
+        [0, 5],       // 6
+        [-5, 0],      // 7
+        [0, null],    // 8
+        [null, 0],    // 9
+    ];
+
+    it('login as super', shared.loginFn(config.superUser));
+
+    cases.forEach(([min, max], index) => {
+        const scaleLimits = {};
+        if (min === 0 || min) {
+            scaleLimits.min = min;
+        }
+        if (max === 0 || max) {
+            scaleLimits.max = max;
+        }
+        const options = { type: 'scale', scaleLimits };
+        it(`create question ${index}`, tests.createQuestionFn(options));
+        it(`get question ${index}`, tests.getQuestionFn(index));
+        it(`verify question ${index}`, tests.verifyQuestionFn(index));
+    });
+
+    const errorQuestion = generator.newQuestion({ type: 'scale', scaleLimits: { min: 3, max: 2 } });
+    it('error: scale minimum is greater than maximum', function errorMinGtMax() {
+        return rrSuperTest.post('/questions', errorQuestion, 400)
+             .then(res => shared.verifyErrorMessage(res, 'questionScaleMinGTMax'));
+    });
+
+    it('list questions 2, 4, 5', function listIded() {
+        const indices = [2, 4, 5];
+        const ids = indices.map(i => hxQuestion.id(i));
+        return models.question.listQuestions({ scope: 'complete', ids })
+            .then((questions) => {
+                const expected = hxQuestion.listServers(null, indices);
+                expect(questions).to.deep.equal(expected);
+            });
+    });
+
+    it('list all questions (complete)', tests.listQuestionsFn('complete'));
+
+    it('list all questions (summary)', tests.listQuestionsFn('summary'));
+
+    it('list all questions (default - summary)', tests.listQuestionsFn());
+
+    it('create all scale survey',
+        surveyTests.createSurveyQxHxFn(_.range(cases.length)));
+    it('get all scale survey', surveyTests.getSurveyFn(0));
+
+    const userCount = 2;
+    _.range(userCount + 1).forEach((i) => {
+        it(`create user ${i}`, shared.createUserFn(hxUser));
+    });
+
+    it('logout as super', shared.logoutFn());
+
+    it('login as user 0', shared.loginIndexFn(hxUser, 0));
+    it('user 0 answers survey 0', answerTests.answerSurveyFn(0, 0, _.range(cases.length)));
+    it('user 0 gets answers to survey 0', answerTests.getAnswersFn(0, 0));
+    it('logout as user 0', shared.logoutFn());
+
+    const errorCases = [
+        { qxIndex: 0, numberValue: 6 },
+        { qxIndex: 1, numberValue: 4 },
+        { qxIndex: 2, numberValue: 6 },
+        { qxIndex: 2, numberValue: 100.0 },
+        { qxIndex: 3, numberValue: 0 },
+        { qxIndex: 3, numberValue: 4 },
+        { qxIndex: 4, numberValue: 1.3 },
+        { qxIndex: 5, numberValue: 6.5 },
+        { qxIndex: 6, numberValue: -1 },
+        { qxIndex: 6, numberValue: 10 },
+        { qxIndex: 7, numberValue: -10.1 },
+        { qxIndex: 7, numberValue: 1 },
+        { qxIndex: 8, numberValue: -1 },
+        { qxIndex: 9, numberValue: 5 },
+    ];
+
+    it('login as user 1', shared.loginIndexFn(hxUser, 1));
+    errorCases.forEach(({ qxIndex, numberValue }, index) => {
+        it(`error: answer out of scale case ${index}`, function errorOutOfLimits() {
+            const answers = [{
+                questionId: hxQuestion.id(qxIndex),
+                answer: { numberValue },
+            }];
+            const surveyId = hxSurvey.id(0);
+            const status = 'in-progress';
+            return rrSuperTest.post(`/user-surveys/${surveyId}/answers`, { status, answers }, 400)
+                .then(res => shared.verifyErrorMessage(res, 'answerOutOfScale', numberValue));
+        });
+    });
+    it('logout as user 1', shared.logoutFn());
+
+    it('login as super', shared.loginFn(config.superUser));
+
+    cases.forEach(([min, max], caseIndex) => {
+        const scaleLimits = {};
+        if (min === 0 || min) {
+            scaleLimits.min = min;
+        }
+        if (max === 0 || max) {
+            scaleLimits.max = max;
+        }
+        const index = cases.length + caseIndex;
+        const options = { type: 'scale', scaleLimits, multi: true };
+        it(`create question ${index}`, tests.createQuestionFn(options));
+        it(`get question ${index}`, tests.getQuestionFn(index));
+        it(`verify question ${index}`, tests.verifyQuestionFn(index));
+    });
+
+    const multiCases = _.range(cases.length).map(index => index + cases.length);
+    it('create all multiple scale survey',
+        surveyTests.createSurveyQxHxFn(multiCases));
+    it('get all multiple scale survey', surveyTests.getSurveyFn(1));
+
+    it('logout as super', shared.logoutFn());
+
+    it('login as user 1', shared.loginIndexFn(hxUser, 1));
+    it('user 1 answers survey 1', answerTests.answerSurveyFn(1, 1, multiCases));
+    it('user 1 gets answers to survey 1', answerTests.getAnswersFn(1, 1));
+    it('logout as user 1', shared.logoutFn());
+
+    it('login as user 0', shared.loginIndexFn(hxUser, 0));
+    const multiErrorCases = [
+        { qxIndex: 0, numberValues: [3, 6], value: 6 },
+        { qxIndex: 1, numberValues: [10, 11, 4], value: 4 },
+        { qxIndex: 2, numberValues: [6], value: 6 },
+        { qxIndex: 2, numberValues: [100.0], value: 100.0 },
+        { qxIndex: 3, numberValues: [0], value: 0 },
+        { qxIndex: 3, numberValues: [4], value: 4 },
+        { qxIndex: 4, numberValues: [1.3], value: 1.3 },
+        { qxIndex: 5, numberValues: [6.5], value: 6.5 },
+        { qxIndex: 6, numberValues: [-1], value: -1 },
+        { qxIndex: 6, numberValues: [10], value: 10 },
+        { qxIndex: 7, numberValues: [-10.1], value: -10.1 },
+        { qxIndex: 7, numberValues: [1], value: 1 },
+        { qxIndex: 8, numberValues: [-1, 5, -4], value: -1 },
+        { qxIndex: 9, numberValues: [5, -5], value: 5 },
+    ];
+
+    multiErrorCases.forEach(({ qxIndex, numberValues, value }, index) => {
+        it(`error: answer out of multi scale case ${index}`, function errorOutOfLimits() {
+            const answers = [{
+                questionId: hxQuestion.id(qxIndex),
+                answers: numberValues.map(numberValue => ({ numberValue })),
+            }];
+            const surveyId = hxSurvey.id(1);
+            const status = 'in-progress';
+            return rrSuperTest.post(`/user-surveys/${surveyId}/answers`, { status, answers }, 400)
+                .then(res => shared.verifyErrorMessage(res, 'answerOutOfScale', value));
+        });
+    });
+
+    it('logout as user 0', shared.logoutFn());
+});

--- a/test/question_scale.model.spec.js
+++ b/test/question_scale.model.spec.js
@@ -1,0 +1,180 @@
+/* global describe,before,it */
+
+'use strict';
+
+process.env.NODE_ENV = 'test';
+
+const chai = require('chai');
+const _ = require('lodash');
+
+const models = require('../models');
+
+const SharedSpec = require('./util/shared-spec.js');
+const Generator = require('./util/generator');
+const History = require('./util/history');
+const SurveyHistory = require('./util/survey-history');
+const questionCommon = require('./util/question-common');
+const surveyCommon = require('./util/survey-common');
+const answerCommon = require('./util/answer-common');
+
+const expect = chai.expect;
+const generator = new Generator();
+const shared = new SharedSpec(generator);
+
+describe('scale type question unit', function scaleQuestionUnit() {
+    before(shared.setUpFn());
+
+    const hxQuestion = new History();
+    const hxSurvey = new SurveyHistory();
+    const hxUser = new History();
+
+    const tests = new questionCommon.SpecTests({ generator, hxQuestion });
+    const surveyTests = new surveyCommon.SpecTests(generator, hxSurvey, hxQuestion);
+    const answerTests = new answerCommon.SpecTests({ generator, hxUser, hxSurvey, hxQuestion });
+
+    const cases = [
+        [null, 5],    // 0
+        [5, null],    // 1
+        [7, 81],      // 2
+        [0.5, 1.45],  // 3
+        [1.4, null],  // 4
+        [null, 5.15], // 5
+        [0, 5],       // 6
+        [-5, 0],      // 7
+        [0, null],    // 8
+        [null, 0],    // 9
+    ];
+
+    cases.forEach(([min, max], index) => {
+        const scaleLimits = {};
+        if (min === 0 || min) {
+            scaleLimits.min = min;
+        }
+        if (max === 0 || max) {
+            scaleLimits.max = max;
+        }
+        const options = { type: 'scale', scaleLimits };
+        it(`create question ${index}`, tests.createQuestionFn(options));
+        it(`get question ${index}`, tests.getQuestionFn(index));
+        it(`verify question ${index}`, tests.verifyQuestionFn(index));
+    });
+
+    const errorQuestion = generator.newQuestion({ type: 'scale', scaleLimits: { min: 3, max: 2 } });
+    it('error: scale minimum is greater than maximum', function errorMinGtMax() {
+        return models.question.createQuestion(errorQuestion)
+            .then(shared.throwingHandler, shared.expectedErrorHandler('questionScaleMinGTMax'));
+    });
+
+    it('list questions 2, 4, 5', function listIded() {
+        const indices = [2, 4, 5];
+        const ids = indices.map(i => hxQuestion.id(i));
+        return models.question.listQuestions({ scope: 'complete', ids })
+            .then((questions) => {
+                const expected = hxQuestion.listServers(null, indices);
+                expect(questions).to.deep.equal(expected);
+            });
+    });
+
+    it('list all questions (complete)', tests.listQuestionsFn('complete'));
+
+    it('list all questions (summary)', tests.listQuestionsFn('summary'));
+
+    it('list all questions (default - summary)', tests.listQuestionsFn());
+
+    it('create all scale survey',
+        surveyTests.createSurveyQxHxFn(_.range(cases.length)));
+    it('get all scale survey', surveyTests.getSurveyFn(0));
+
+    const userCount = 2;
+    _.range(userCount + 1).forEach((i) => {
+        it(`create user ${i}`, shared.createUserFn(hxUser));
+    });
+
+    it('user 0 answers survey 0', answerTests.answerSurveyFn(0, 0, _.range(cases.length)));
+    it('user 0 gets answers to survey 0', answerTests.getAnswersFn(0, 0));
+
+    const errorCases = [
+        { qxIndex: 0, numberValue: 6 },
+        { qxIndex: 1, numberValue: 4 },
+        { qxIndex: 2, numberValue: 6 },
+        { qxIndex: 2, numberValue: 100.0 },
+        { qxIndex: 3, numberValue: 0 },
+        { qxIndex: 3, numberValue: 4 },
+        { qxIndex: 4, numberValue: 1.3 },
+        { qxIndex: 5, numberValue: 6.5 },
+        { qxIndex: 6, numberValue: -1 },
+        { qxIndex: 6, numberValue: 10 },
+        { qxIndex: 7, numberValue: -10.1 },
+        { qxIndex: 7, numberValue: 1 },
+        { qxIndex: 8, numberValue: -1 },
+        { qxIndex: 9, numberValue: 5 },
+    ];
+
+    errorCases.forEach(({ qxIndex, numberValue }, index) => {
+        it(`error: answer out of scale case ${index}`, function errorOutOfLimits() {
+            const answers = [{
+                questionId: hxQuestion.id(qxIndex),
+                answer: { numberValue },
+            }];
+            const userId = hxUser.id(1);
+            const surveyId = hxSurvey.id(0);
+            const status = 'in-progress';
+            return models.userSurvey.createUserSurveyAnswers(userId, surveyId, { status, answers })
+                .then(shared.throwingHandler, shared.expectedErrorHandler('answerOutOfScale', numberValue));
+        });
+    });
+
+    cases.forEach(([min, max], caseIndex) => {
+        const scaleLimits = {};
+        if (min === 0 || min) {
+            scaleLimits.min = min;
+        }
+        if (max === 0 || max) {
+            scaleLimits.max = max;
+        }
+        const index = cases.length + caseIndex;
+        const options = { type: 'scale', scaleLimits, multi: true };
+        it(`create question ${index}`, tests.createQuestionFn(options));
+        it(`get question ${index}`, tests.getQuestionFn(index));
+        it(`verify question ${index}`, tests.verifyQuestionFn(index));
+    });
+
+    const multiCases = _.range(cases.length).map(index => index + cases.length);
+    it('create all multiple scale survey',
+        surveyTests.createSurveyQxHxFn(multiCases));
+    it('get all multiple scale survey', surveyTests.getSurveyFn(1));
+
+    it('user 1 answers survey 1', answerTests.answerSurveyFn(1, 1, multiCases));
+    it('user 1 gets answers to survey 1', answerTests.getAnswersFn(1, 1));
+
+    const multiErrorCases = [
+        { qxIndex: 0, numberValues: [3, 6], value: 6 },
+        { qxIndex: 1, numberValues: [10, 11, 4], value: 4 },
+        { qxIndex: 2, numberValues: [6], value: 6 },
+        { qxIndex: 2, numberValues: [100.0], value: 100.0 },
+        { qxIndex: 3, numberValues: [0], value: 0 },
+        { qxIndex: 3, numberValues: [4], value: 4 },
+        { qxIndex: 4, numberValues: [1.3], value: 1.3 },
+        { qxIndex: 5, numberValues: [6.5], value: 6.5 },
+        { qxIndex: 6, numberValues: [-1], value: -1 },
+        { qxIndex: 6, numberValues: [10], value: 10 },
+        { qxIndex: 7, numberValues: [-10.1], value: -10.1 },
+        { qxIndex: 7, numberValues: [1], value: 1 },
+        { qxIndex: 8, numberValues: [-1, 5, -4], value: -1 },
+        { qxIndex: 9, numberValues: [5, -5], value: 5 },
+    ];
+
+    multiErrorCases.forEach(({ qxIndex, numberValues, value }, index) => {
+        it(`error: answer out of multi scale case ${index}`, function errorOutOfLimits() {
+            const answers = [{
+                questionId: hxQuestion.id(qxIndex),
+                answers: numberValues.map(numberValue => ({ numberValue })),
+            }];
+            const userId = hxUser.id(0);
+            const surveyId = hxSurvey.id(1);
+            const status = 'in-progress';
+            return models.userSurvey.createUserSurveyAnswers(userId, surveyId, { status, answers })
+                .then(shared.throwingHandler, shared.expectedErrorHandler('answerOutOfScale', value));
+        });
+    });
+});

--- a/test/util/generator/answerer.js
+++ b/test/util/generator/answerer.js
@@ -94,6 +94,20 @@ module.exports = class Answerer {
         return { boolValue: (answerIndex % 2) === 0 };
     }
 
+    scale(question) {
+        const { min, max } = question.meta.scaleLimits;
+        if (min !== undefined && max !== undefined) {
+            return { numberValue: (min + max) / 2 };
+        }
+        if (min !== undefined) {
+            return { numberValue: min + 0.5 };
+        }
+        if (max !== undefined) {
+            return { numberValue: max - 0.5 };
+        }
+        return { numberValue: 0 };
+    }
+
     selectChoice(choices) {
         const answerIndex = this.answerIndex;
         return choices[answerIndex % choices.length];

--- a/test/util/generator/answerer.js
+++ b/test/util/generator/answerer.js
@@ -96,7 +96,7 @@ module.exports = class Answerer {
 
     scale(question) {
         const answerIndex = this.answerIndex;
-        const { min, max } = question.meta.scaleLimits;
+        const { min, max } = question.scaleLimits;
         if (min !== undefined && max !== undefined) {
             return { numberValue: min + (answerIndex % (max - min)) };
         }

--- a/test/util/generator/answerer.js
+++ b/test/util/generator/answerer.js
@@ -95,15 +95,16 @@ module.exports = class Answerer {
     }
 
     scale(question) {
+        const answerIndex = this.answerIndex;
         const { min, max } = question.meta.scaleLimits;
         if (min !== undefined && max !== undefined) {
-            return { numberValue: (min + max) / 2 };
+            return { numberValue: min + (answerIndex % (max - min)) };
         }
         if (min !== undefined) {
-            return { numberValue: min + 0.5 };
+            return { numberValue: min + answerIndex };
         }
         if (max !== undefined) {
-            return { numberValue: max - 0.5 };
+            return { numberValue: max - answerIndex };
         }
         return { numberValue: 0 };
     }

--- a/test/util/generator/conditional-survey-generator.js
+++ b/test/util/generator/conditional-survey-generator.js
@@ -14,10 +14,13 @@ const specialQuestionGenerator = {
         return surveyGenerator.questionGenerator.newMultiQuestion(options);
     },
     type(surveyGenerator, questionInfo) {
-        const { type, choiceCount, isIdentifying } = questionInfo;
+        const { type, choiceCount, isIdentifying, scaleLimits } = questionInfo;
         const options = { type };
         if (choiceCount) {
             options.choiceCount = choiceCount;
+        }
+        if (scaleLimits) {
+            options.scaleLimits = scaleLimits;
         }
         const question = surveyGenerator.questionGenerator.newQuestion(options);
         if (isIdentifying) {

--- a/test/util/generator/question-generator.js
+++ b/test/util/generator/question-generator.js
@@ -9,6 +9,7 @@ const singleQuestionTypes = [
     'integer', 'zip', 'pounds', 'float',
     'date', 'year', 'month', 'day',
     'feet-inches', 'blood-pressure',
+    'scale',
 ];
 
 const virtualQuestionTypes = [
@@ -159,6 +160,27 @@ module.exports = class QuestionGenerator {
             return r;
         });
         question.choices = choices;
+        return question;
+    }
+
+    scale(options) {
+        const question = this.body('scale');
+        if (!question.meta) {
+            question.meta = {};
+        }
+        if (options.scaleLimits) {
+            Object.assign(question.meta, { scaleLimits: options.scaleLimits });
+            return question;
+        }
+        const scaleLimits = {};
+        const value = this.index % 3;
+        if (value === 0 || value === 1) {
+            scaleLimits.min = 10.5 + value;
+        }
+        if (value === 1 || value === 2) {
+            scaleLimits.max = 90.5 + value;
+        }
+        Object.assign(question.meta, { scaleLimits });
         return question;
     }
 

--- a/test/util/generator/question-generator.js
+++ b/test/util/generator/question-generator.js
@@ -170,11 +170,11 @@ module.exports = class QuestionGenerator {
             return question;
         }
         const scaleLimits = {};
-        const value = this.index % 3;
-        if (value === 0 || value === 1) {
+        const value = this.index % 5;
+        if (value <= 3) {
             scaleLimits.min = 10.5 + value;
         }
-        if (value === 1 || value === 2) {
+        if (value >= 2) {
             scaleLimits.max = 90.5 + value;
         }
         question.scaleLimits = scaleLimits;

--- a/test/util/generator/question-generator.js
+++ b/test/util/generator/question-generator.js
@@ -165,11 +165,8 @@ module.exports = class QuestionGenerator {
 
     scale(options) {
         const question = this.body('scale');
-        if (!question.meta) {
-            question.meta = {};
-        }
         if (options.scaleLimits) {
-            Object.assign(question.meta, { scaleLimits: options.scaleLimits });
+            question.scaleLimits = options.scaleLimits;
             return question;
         }
         const scaleLimits = {};
@@ -180,7 +177,7 @@ module.exports = class QuestionGenerator {
         if (value === 1 || value === 2) {
             scaleLimits.max = 90.5 + value;
         }
-        Object.assign(question.meta, { scaleLimits });
+        question.scaleLimits = options.scaleLimits;
         return question;
     }
 

--- a/test/util/generator/question-generator.js
+++ b/test/util/generator/question-generator.js
@@ -177,7 +177,7 @@ module.exports = class QuestionGenerator {
         if (value === 1 || value === 2) {
             scaleLimits.max = 90.5 + value;
         }
-        question.scaleLimits = options.scaleLimits;
+        question.scaleLimits = scaleLimits;
         return question;
     }
 

--- a/test/util/generator/survey-patch-generator.js
+++ b/test/util/generator/survey-patch-generator.js
@@ -76,6 +76,13 @@ const specHandler = {
             }
         });
     },
+    patchScaleQuestions(patch, generator, spec) {
+        patch.questions.forEach(question => {
+            if (question.type === 'scale') {
+                question.scaleLimits = spec.patch.scaleLimits;
+            }
+        });
+    },
     patchQuestionChoice(patch, generator, spec) {
         const question = patch.questions[spec.questionIndex];
         const choice = question.choices[spec.questionChoiceIndex];
@@ -170,6 +177,15 @@ const patchComparators = {
         keys.forEach((key) => {
             if (spec.patch[key] === null) {
                 delete question[key];
+            }
+        });
+    },
+    patchScaleQuestions(spec, survey, surveyPatch, patchedSurvey) {
+        survey.questions.forEach((question, index) => {
+            if (question.type === 'scale') {
+                const patchedQuestion = patchedSurvey.questions[index];
+                expect(question.scaleLimits).not.deep.equal(patchedQuestion.scaleLimits);
+                question.scaleLimits = spec.patch.scaleLimits;
             }
         });
     },

--- a/test/util/generator/survey-patch-generator.js
+++ b/test/util/generator/survey-patch-generator.js
@@ -76,13 +76,6 @@ const specHandler = {
             }
         });
     },
-    patchScaleQuestions(patch, generator, spec) {
-        patch.questions.forEach(question => {
-            if (question.type === 'scale') {
-                question.scaleLimits = spec.patch.scaleLimits;
-            }
-        });
-    },
     patchQuestionChoice(patch, generator, spec) {
         const question = patch.questions[spec.questionIndex];
         const choice = question.choices[spec.questionChoiceIndex];
@@ -177,15 +170,6 @@ const patchComparators = {
         keys.forEach((key) => {
             if (spec.patch[key] === null) {
                 delete question[key];
-            }
-        });
-    },
-    patchScaleQuestions(spec, survey, surveyPatch, patchedSurvey) {
-        survey.questions.forEach((question, index) => {
-            if (question.type === 'scale') {
-                const patchedQuestion = patchedSurvey.questions[index];
-                expect(question.scaleLimits).not.deep.equal(patchedQuestion.scaleLimits);
-                question.scaleLimits = spec.patch.scaleLimits;
             }
         });
     },

--- a/test/util/question-common.js
+++ b/test/util/question-common.js
@@ -187,7 +187,10 @@ const BaseTests = class BaseTests {
         const self = this;
         return function patchQuestion() {
             const question = self.hxQuestion.server(index);
-            Object.assign(question, patch);
+            if (question.scaleLimits && patch.scaleLimits) {
+                _.merge(question.scaleLimits, patch.scaleLimits);
+            }
+            Object.assign(question, _.omit(patch, 'scaleLimits'));
             _.forOwn(patch, (value, key) => {
                 if (value === null) {
                     if (key === 'common') {
@@ -209,7 +212,10 @@ const BaseTests = class BaseTests {
         const self = this;
         return function patchQuestion() {
             const question = _.cloneDeep(self.hxQuestion.server(index));
-            Object.assign(question, patch);
+            if (question.scaleLimits && patch.scaleLimits) {
+                _.merge(question.scaleLimits, patch.scaleLimits);
+            }
+            Object.assign(question, _.omit(patch, 'scaleLimits'));
             let errFn;
             if (options.errorParam) {
                 errFn = errSpec.expectedErrorHandlerFn(options.error, options.errorParam);

--- a/test/util/question-common.js
+++ b/test/util/question-common.js
@@ -11,9 +11,9 @@ const comparator = require('./comparator');
 const errSpec = require('./err-handler-spec');
 
 const scopeToFieldsMap = {
-    summary: ['id', 'isIdentifying', 'type', 'text', 'instruction'],
+    summary: ['id', 'isIdentifying', 'scaleLimits', 'type', 'text', 'instruction'],
     complete: null,
-    export: ['id', 'isIdentifying', 'type', 'text', 'instruction', 'choices', 'meta'],
+    export: ['id', 'isIdentifying', 'scaleLimits', 'type', 'text', 'instruction', 'choices', 'meta'],
 };
 
 const expect = chai.expect;

--- a/test/util/question-common.js
+++ b/test/util/question-common.js
@@ -187,10 +187,7 @@ const BaseTests = class BaseTests {
         const self = this;
         return function patchQuestion() {
             const question = self.hxQuestion.server(index);
-            if (question.scaleLimits && patch.scaleLimits) {
-                _.merge(question.scaleLimits, patch.scaleLimits);
-            }
-            Object.assign(question, _.omit(patch, 'scaleLimits'));
+            Object.assign(question, patch);
             _.forOwn(patch, (value, key) => {
                 if (value === null) {
                     if (key === 'common') {
@@ -212,10 +209,7 @@ const BaseTests = class BaseTests {
         const self = this;
         return function patchQuestion() {
             const question = _.cloneDeep(self.hxQuestion.server(index));
-            if (question.scaleLimits && patch.scaleLimits) {
-                _.merge(question.scaleLimits, patch.scaleLimits);
-            }
-            Object.assign(question, _.omit(patch, 'scaleLimits'));
+            Object.assign(question, patch);
             let errFn;
             if (options.errorParam) {
                 errFn = errSpec.expectedErrorHandlerFn(options.error, options.errorParam);


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.

Please refer to [Tettra](https://app.tettra.co/teams/amida/pages/amida-pull-request-and-code-review-guide) for PR review guidelines.

#### What does this PR do?
This adds the "scale" question type, which is allows min and max limits on a number input. This was adapted from a similar feature added to survey service. See https://github.com/amida-tech/amida-survey-microservice/pull/38

#### Related JIRA tickets:
RR-756

#### How should this be manually tested?
Create/get/export/import scale questions and answer them.

1. Scale questions are specified using type scale and property meta: { scaleLimits: {min: , max: }}.
2. Min and max are optional but at least one of them should be present.
3. When both present max needs to be greater or equal to min.
4. Answers to scale questions are specified using numberValue which accepts float.
5. Answers will be validated when posted according to min and max.

#### Background/Context

#### Screenshots (if appropriate):