### PR TITLE
Feature/rr 952 allow patch with no choices

### DIFF
--- a/models/dao/question-choice.dao.js
+++ b/models/dao/question-choice.dao.js
@@ -278,7 +278,7 @@ module.exports = class QuestionChoiceDAO extends Translatable {
     }
 
     patchChoicesForQuestion(questionId, choices, choicesPatch, transaction, options) {
-        const choiceMap = choices.reduce((r, choice, line) => {
+        const choiceMap = (choices || []).reduce((r, choice, line) => {
             const record = Object.assign({ line }, choice);
             r[choice.id] = record;
             return r;
@@ -288,7 +288,7 @@ module.exports = class QuestionChoiceDAO extends Translatable {
             newChoices,
             changedChoices,
             choicesPatchMap,
-        } = choicesPatch.reduce((r, choicePatch, line) => {
+        } = (choicesPatch || []).reduce((r, choicePatch, line) => {
             const id = choicePatch.id;
             const record = Object.assign({ line }, choicePatch);
             if (id) {
@@ -310,7 +310,7 @@ module.exports = class QuestionChoiceDAO extends Translatable {
             return r;
         }, { newChoices: [], changedChoices: [], choicesPatchMap: {} });
 
-        const deletedIds = choices.reduce((r, choice) => {
+        const deletedIds = (choices || []).reduce((r, choice) => {
             const id = choice.id;
             if (!choicesPatchMap[id]) {
                 r.push(id);

--- a/models/dao/question.dao.js
+++ b/models/dao/question.dao.js
@@ -461,10 +461,8 @@ module.exports = class QuestionDAO extends Translatable {
                     .then(() => {
                         if (scope !== 'summary') {
                             questions.forEach((q) => {
-                                if (isDirectChoiceType(q)) {
-                                    if (!q.choices) {
-                                        q.choices = [];
-                                    }
+                                if (isDirectChoiceType(q) && !q.choices) {
+                                    q.choices = [];
                                 }
                             });
                         }

--- a/models/dao/question.dao.js
+++ b/models/dao/question.dao.js
@@ -11,6 +11,12 @@ const ImportCSVConverter = require('../../import/csv-converter.js');
 
 const Op = Sequelize.Op;
 
+const choiceTypes = ['choice', 'open-choice', 'choices'];
+
+const isDirectChoiceType = function (question) {
+    return choiceTypes.indexOf(question.type) >= 0;
+};
+
 const cleanDBQuestion = function (question) {
     const result = _.omitBy(question, _.isNil);
     if (question.common === null) {
@@ -232,7 +238,7 @@ module.exports = class QuestionDAO extends Translatable {
             })
             .then(question => this.updateText(question, language))
             .then((question) => {
-                if (['choice', 'open-choice', 'choices'].indexOf(question.type) < 0) {
+                if (!isDirectChoiceType(question)) {
                     return question;
                 }
                 return this.questionChoice.findChoicesPerQuestion(question.id, options.language)
@@ -452,7 +458,18 @@ module.exports = class QuestionDAO extends Translatable {
                         }
                         return null;
                     })
-                    .then(() => questions);
+                    .then(() => {
+                        if (scope !== 'summary') {
+                            questions.forEach((q) => {
+                                if (isDirectChoiceType(q)) {
+                                    if (!q.choices) {
+                                        q.choices = [];
+                                    }
+                                }
+                            });
+                        }
+                        return questions;
+                    });
             });
     }
 
@@ -672,14 +689,11 @@ module.exports = class QuestionDAO extends Translatable {
             .then(() => {
                 const chs = question.choices;
                 const chsPatch = patch.choices;
-                if (Boolean(chs) !== Boolean(chsPatch)) {
-                    return RRError.reject('qxPatchNoChoicesChange');
+                if (!isDirectChoiceType(question)) {
+                    return {};
                 }
-                if (chs) {
-                    const opts = { force: patch.force, language };
-                    return this.questionChoice.patchChoicesForQuestion(id, chs, chsPatch, tx, opts);
-                }
-                return {};
+                const opts = { force: patch.force, language };
+                return this.questionChoice.patchChoicesForQuestion(id, chs, chsPatch, tx, opts);
             });
     }
 

--- a/test/fixtures/conditional-session/patch/patch-setup.js
+++ b/test/fixtures/conditional-session/patch/patch-setup.js
@@ -128,4 +128,15 @@ module.exports = [{
             },
         },
     }],
+}, { // ^10, v 11
+    surveyIndex: 9,
+    mods: [{
+        purpose: 'addChoices',
+        questionIndex: 2,
+        newChoiceCount: 4,
+    }, {
+        purpose: 'addChoices',
+        questionIndex: 5,
+        newChoiceCount: 4,
+    }],
 }];

--- a/test/fixtures/conditional-session/patch/setup.js
+++ b/test/fixtures/conditional-session/patch/setup.js
@@ -118,4 +118,16 @@ module.exports = [{
     questionIndex: 5,
     logic: 'equals',
     relativeIndex: 2,
+}, { // Survey 9
+    surveyIndex: 9,
+    purpose: 'type',
+    questionIndex: 2,
+    type: 'choices',
+    choiceCount: 0,
+}, {
+    surveyIndex: 9,
+    purpose: 'type',
+    questionIndex: 5,
+    type: 'choice',
+    choiceCount: 0,
 }];

--- a/test/question_patch.model.spec.js
+++ b/test/question_patch.model.spec.js
@@ -97,15 +97,6 @@ describe('question patch unit', function questionPatchUnit() {
         it(`error: patch type related fields (${index})`, tests.errorPatchQuestionFn(0, patch, options));
     });
 
-    it('error: no choices for previously choices', function errorNoChoicesToChoices() {
-        return tests.errorPatchQuestionFn(0, { choices: null }, { error: 'qxPatchNoChoicesChange' })();
-    });
-
-    it('error: choices for previously no choices', function errorChoicesToNoChoices() {
-        const choices = hxQuestion.server(0).choices;
-        return tests.errorPatchQuestionFn(5, { choices }, { error: 'qxPatchNoChoicesChange' })();
-    });
-
     [0, 2].forEach((index) => {
         it('error: add choices with id', function errorAddChoicesWithId() {
             const choices = hxQuestion.server(index + 1).choices;

--- a/test/util/comparator.js
+++ b/test/util/comparator.js
@@ -59,7 +59,7 @@ const comparator = {
     question(client, server, options = {}) {
         const id = server.id;
         const expected = _.cloneDeep(client);
-        if (expected.type === 'choices') {
+        if (expected.type === 'choices' && expected.choices) {
             expected.choices.forEach((choice) => { choice.type = choice.type || 'bool'; });
         }
         if (expected.type === 'choice' && expected.oneOfChoices) {
@@ -94,17 +94,19 @@ const comparator = {
         }
         expect(server.type).to.equal(expected.type);
         if (expected.type === 'choice' || expected.type === 'open-choice' || expected.type === 'choices' || expected.type === 'choice-ref') {
-            expected.choices.forEach((choice, index) => {
-                choice.id = server.choices[index].id;
-                if (options.ignoreAnswerIdentifier) {
-                    delete choice.answerIdentifier;
-                } else if (choice.answerIdentifier) {
-                    if (choice.answerIdentifier.type === 'federated') {
-                        choice.identifier = choice.answerIdentifier.value;
+            if (expected.choices) {
+                expected.choices.forEach((choice, index) => {
+                    choice.id = server.choices[index].id;
+                    if (options.ignoreAnswerIdentifier) {
+                        delete choice.answerIdentifier;
+                    } else if (choice.answerIdentifier) {
+                        if (choice.answerIdentifier.type === 'federated') {
+                            choice.identifier = choice.answerIdentifier.value;
+                        }
+                        delete choice.answerIdentifier;
                     }
-                    delete choice.answerIdentifier;
-                }
-            });
+                });
+            }
         }
         if (options.identifiers) {
             const identifiers = options.identifiers[id];

--- a/test/util/generator/conditional-survey-generator.js
+++ b/test/util/generator/conditional-survey-generator.js
@@ -40,7 +40,7 @@ const specialQuestionGenerator = {
     type(surveyGenerator, questionInfo) {
         const { type, choiceCount, isIdentifying, scaleLimits } = questionInfo;
         const options = { type };
-        if (choiceCount) {
+        if (choiceCount || choiceCount === 0) {
             options.choiceCount = choiceCount;
         }
         if (scaleLimits) {

--- a/test/util/generator/question-generator.js
+++ b/test/util/generator/question-generator.js
@@ -91,7 +91,7 @@ module.exports = class QuestionGenerator {
         const typeChoiceIndex = this.typeChoiceIndex;
         const question = this.body('choice');
         if (choiceCount === 0) {
-            return question;
+            return Object.assign(question, { choices: [] });
         }
         const choices = this.newChoices(choiceCount);
         if (((typeChoiceIndex % 3) === 0) && !noOneOf) {
@@ -129,7 +129,7 @@ module.exports = class QuestionGenerator {
         let choices;
         const choiceCount = options.choiceCount;
         if (choiceCount === 0) {
-            return question;
+            return Object.assign(question, { choices: [] });
         }
         const newChoices = this.newChoices(choiceCount);
         if (this.choicesCode) {

--- a/test/util/generator/question-generator.js
+++ b/test/util/generator/question-generator.js
@@ -86,11 +86,14 @@ module.exports = class QuestionGenerator {
     }
 
     choice(options = {}) {
-        const noOneOf = options.noOneOf;
+        const { noOneOf, choiceCount } = options;
         this.typeChoiceIndex += 1;
         const typeChoiceIndex = this.typeChoiceIndex;
         const question = this.body('choice');
-        const choices = this.newChoices(options.choiceCount);
+        if (choiceCount === 0) {
+            return question;
+        }
+        const choices = this.newChoices(choiceCount);
         if (((typeChoiceIndex % 3) === 0) && !noOneOf) {
             question.oneOfChoices = choices;
         } else if ((typeChoiceIndex % 3) === 1) {
@@ -125,6 +128,9 @@ module.exports = class QuestionGenerator {
         const question = this.body('choices');
         let choices;
         const choiceCount = options.choiceCount;
+        if (choiceCount === 0) {
+            return question;
+        }
         const newChoices = this.newChoices(choiceCount);
         if (this.choicesCode) {
             this.choicesCode = false;

--- a/test/util/generator/survey-patch-generator.js
+++ b/test/util/generator/survey-patch-generator.js
@@ -98,7 +98,12 @@ const specHandler = {
         const questionGenerator = generator.generator.questionGenerator;
         const newChoices = questionGenerator.newChoices(newChoiceCount);
         const newQxChoices = newChoices.map(ch => ({ text: ch }));
-        patch.questions[questionIndex].choices.push(...newQxChoices);
+        const { choices } = patch.questions[questionIndex];
+        if (choices) {
+            choices.push(...newQxChoices);
+        } else {
+            Object.assign(patch.questions[questionIndex], { choices: newQxChoices });
+        }
     },
 };
 
@@ -201,11 +206,17 @@ const patchComparators = {
         const choices = question.choices;
         const patchedQuestion = patchedSurvey.questions[questionIndex];
         const patchedChoices = patchedQuestion.choices;
-        expect(choices.length + newChoiceCount).to.equal(patchedChoices.length);
+        const choiceCount = (choices && choices.length) || 0;
+        const patchedCount = (patchedChoices && patchedChoices.length) || 0;
+        expect(choiceCount + newChoiceCount).to.equal(patchedCount);
         const questionPatch = surveyPatch.questions[questionIndex];
         comparator.question(questionPatch, patchedQuestion);
-        choices.length = 0;
-        choices.push(...patchedChoices);
+        if (choices) {
+            choices.length = 0;
+            choices.push(...patchedChoices);
+        } else {
+            question.choices = patchedChoices;
+        }
     },
 };
 


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.

Please refer to [Tettra](https://app.tettra.co/teams/amida/pages/amida-pull-request-and-code-review-guide) for PR review guidelines.

#### What does this PR do? This adds the ability to patch add choices to questions (choice and choices types) that had no choices before.

#### Related JIRA tickets: RR-952

#### How should this be manually tested?

1) Create a choice or choices type question without any choices (empty array choices property).
2) Try to add choices using patch.

#### Background/Context

#### Screenshots (if appropriate):
